### PR TITLE
Fix dev container build

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,16 +4,22 @@
     "ghcr.io/anthropics/devcontainer-features/claude-code:1": {},
     "ghcr.io/devcontainers-extra/features/caddy:1": {},
     "ghcr.io/devcontainers/features/aws-cli:1": {},
-    "ghcr.io/devcontainers/features/docker-in-docker": {
+    // Keep every feature version-tagged: Dependabot cannot track an untagged
+    // reference, which is why this one sat on :latest and never got bumped.
+    "ghcr.io/devcontainers/features/docker-in-docker:4": {
       "dockerDashComposeVersion": "v2",
       "moby": false
     },
-    "ghcr.io/devcontainers/features/node:2": { "version": "24" },
-    "./playwright": {}
+    "ghcr.io/devcontainers/features/node:2": { "version": "24" }
   },
   "updateContentCommand": {
     "hooks-setup": ["git", "config", "core.hooksPath", ".hooks"],
-    "cargo-watch": ["cargo", "install", "cargo-watch"]
+    "cargo-watch": ["cargo", "install", "cargo-watch"],
+    // Runs in the workspace as the container user, so `npx` resolves the
+    // @playwright/test version pinned in package.json and the browsers land in
+    // that user's cache. The old ./playwright feature ran at image build time,
+    // before the node feature existed, and failed with "npx: command not found".
+    "playwright": "npm ci && npx playwright install --with-deps"
   },
   "customizations": {
     "vscode": {

--- a/.devcontainer/playwright/devcontainer-feature.json
+++ b/.devcontainer/playwright/devcontainer-feature.json
@@ -1,6 +1,0 @@
-{
-  "id": "playwright",
-  "version": "1.0.0",
-  "name": "Playwright",
-  "description": "Installs Playwright browsers and system dependencies"
-}

--- a/.devcontainer/playwright/install.sh
+++ b/.devcontainer/playwright/install.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-set -e
-# Install Playwright system dependencies and browsers
-npx playwright install --with-deps


### PR DESCRIPTION
The dev container build failed with `npx: command not found`.

The local `./playwright` feature ran at image build time, where feature ordering is undefined, so it could run before the `node` feature installed `npx`. Even when it did not, it ran as root outside the workspace — so `npx playwright` would have fetched the latest release rather than the version pinned in `package.json`, and cached browsers under root instead of the container user.

Replaced with an `updateContentCommand` step that runs in the workspace as the container user. Playwright resolves from `node_modules` and escalates with sudo itself for system dependencies.

Also pinned `docker-in-docker` to `:4` — it was the only untagged feature, and Dependabot cannot track an untagged reference.

Verified by the new `devcontainer` CI job on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)