### PR TITLE
Move to Node 26 and let Dependabot drive future Node majors

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
       "dockerDashComposeVersion": "v2",
       "moby": false
     },
-    "ghcr.io/devcontainers/features/node:2": { "version": "24" }
+    "ghcr.io/devcontainers/features/node:2": { "version": "26" }
   },
   "updateContentCommand": {
     "hooks-setup": ["git", "config", "core.hooksPath", ".hooks"],

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,9 +17,13 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "@types/node"
-        update-types: ["version-update:semver-major"]
+    # One pull request for all npm updates. A Node major shows up as a bump to
+    # @types/node, which is the only part of it Dependabot can update: `engines`,
+    # @tsconfig/nodeNN and the dev container feature option all have to be edited
+    # by hand in the same PR. `npm run check:node` fails the build until they are.
+    groups:
+      npm:
+        patterns: ["*"]
   - package-ecosystem: "devcontainers"
     directory: "/"
     schedule:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Install npm dependencies
         run: npm ci
 
+      - name: Check Node version consistency
+        run: npm run check:node
+
       - name: Typecheck
         run: npm run typecheck
 

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -7,5 +7,6 @@ set -o pipefail
 cargo fmt --check
 caddy fmt --diff Caddyfile
 caddy validate --config Caddyfile --adapter caddyfile
+npm run check:node
 npm run typecheck
 npm run format:check

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "devDependencies": {
         "@playwright/test": "^1.62.1",
         "@tsconfig/node-ts": "^23.6.4",
-        "@tsconfig/node24": "^24.0.4",
-        "@types/node": "^24.13.3",
+        "@tsconfig/node26": "^26.0.0",
+        "@types/node": "^26.1.2",
         "prettier": "^3.9.6",
         "prettier-plugin-jinja-template": "^2.2.0",
         "typescript": "^7.0.2"
@@ -42,21 +42,21 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@tsconfig/node24": {
-      "version": "24.0.4",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node24/-/node24-24.0.4.tgz",
-      "integrity": "sha512-2A933l5P5oCbv6qSxHs7ckKwobs8BDAe9SJ/Xr2Hy+nDlwmLE1GhFh/g/vXGRZWgxBg9nX/5piDtHR9Dkw/XuA==",
+    "node_modules/@tsconfig/node26": {
+      "version": "26.0.0",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node26/-/node26-26.0.0.tgz",
+      "integrity": "sha512-AlW882moMu/JzvTVjdGqJEsrqD5nSWHiFD7Aeuw6Rb58S4Aig+09mDUFFlXJx/y6/y77NwGYLlqhWxvolcC0sw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.18.0"
+        "undici-types": "~8.3.0"
       }
     },
     "node_modules/@typescript/typescript-aix-ppc64": {
@@ -508,9 +508,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -4,15 +4,16 @@
   "license": "UNLICENSED",
   "type": "module",
   "engines": {
-    "node": "^24"
+    "node": "^26"
   },
   "devEngines": {
     "runtime": {
       "name": "node",
-      "version": "^24"
+      "version": "^26"
     }
   },
   "scripts": {
+    "check:node": "node scripts/check-node-version.mjs",
     "typecheck": "tsc",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -22,8 +23,8 @@
   "devDependencies": {
     "@playwright/test": "^1.62.1",
     "@tsconfig/node-ts": "^23.6.4",
-    "@tsconfig/node24": "^24.0.4",
-    "@types/node": "^24.13.3",
+    "@tsconfig/node26": "^26.0.0",
+    "@types/node": "^26.1.2",
     "prettier": "^3.9.6",
     "prettier-plugin-jinja-template": "^2.2.0",
     "typescript": "^7.0.2"

--- a/scripts/check-node-version.mjs
+++ b/scripts/check-node-version.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+//
+// check-node-version.mjs - Fail if the Node major version drifts.
+//
+// The Node major is declared in six places. Dependabot can only update one of
+// them (@types/node): it will not touch `engines`, it cannot rename
+// @tsconfig/nodeNN to the next major, and it does not read the `version` option
+// of a dev container feature.
+//
+// So a Node major bump always arrives as a partial PR. This turns that into a
+// red build on the PR rather than a mismatch discovered later.
+//
+// Usage:
+//   npm run check:node
+//
+
+import { readFileSync } from "node:fs";
+
+/** First run of digits in a value, e.g. "^26.1.2" and "@tsconfig/node26" -> "26". */
+const major = (value) => String(value ?? "").match(/\d+/)?.[0];
+
+const pkg = JSON.parse(readFileSync("package.json", "utf8"));
+const tsconfig = readFileSync("tsconfig.json", "utf8");
+const devcontainer = readFileSync(".devcontainer/devcontainer.json", "utf8");
+
+const devDeps = pkg.devDependencies ?? {};
+
+const declarations = {
+  "package.json engines.node": major(pkg.engines?.node),
+  "package.json devEngines.runtime.version": major(
+    pkg.devEngines?.runtime?.version,
+  ),
+  "package.json @types/node": major(devDeps["@types/node"]),
+  "package.json @tsconfig/nodeNN": major(
+    Object.keys(devDeps).find((name) => /^@tsconfig\/node\d+$/.test(name)),
+  ),
+  "tsconfig.json extends": tsconfig.match(/@tsconfig\/node(\d+)\//)?.[1],
+  ".devcontainer/devcontainer.json node feature": devcontainer.match(
+    /features\/node:\d+"\s*:\s*\{\s*"version"\s*:\s*"(\d+)"/,
+  )?.[1],
+};
+
+const majors = new Set(Object.values(declarations));
+
+if (majors.size === 1 && !majors.has(undefined)) {
+  console.log(
+    `Node ${[...majors][0]} is declared consistently in all ${Object.keys(declarations).length} places.`,
+  );
+  process.exit(0);
+}
+
+console.error("Node major version is inconsistent across the repo:\n");
+for (const [where, found] of Object.entries(declarations)) {
+  console.error(`  ${(found ?? "NOT FOUND").padEnd(9)} ${where}`);
+}
+console.error(
+  "\nA Node major bump has to change all of these together. Dependabot only\n" +
+    "updates @types/node, so the rest are expected to be edited by hand in the\n" +
+    "same pull request.",
+);
+process.exit(1);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "@tsconfig/node24/tsconfig.json",
+    "@tsconfig/node26/tsconfig.json",
     // https://nodejs.org/api/typescript.html#type-stripping
     "@tsconfig/node-ts/tsconfig.json"
   ],


### PR DESCRIPTION
Node 26 is the current release and becomes LTS on 2026-10-28. This moves every declaration of the Node major to 26 and removes the `@types/node` major-version ignore, so future Node majors flow through Dependabot.

### Why this needs more than removing the ignore rule

Dependabot can only update **one** of the six places the Node major is declared. It will not touch `engines`, it cannot rename `@tsconfig/nodeNN` to the next major, and it does not read the `version` option of a dev container feature. A Node major will always arrive as a partial PR.

Two changes make that a single PR to finish rather than a trap:

- **All npm updates are grouped into one PR**, so the `@types/node` bump arrives alongside everything else npm.
- **`npm run check:node`** fails the build when the six declarations disagree, and prints which ones. It runs in the lint job and in the pre-commit hook.

Sample output when only `@types/node` has been bumped:

```
Node major version is inconsistent across the repo:

  26        package.json engines.node
  26        package.json devEngines.runtime.version
  27        package.json @types/node
  26        package.json @tsconfig/nodeNN
  26        tsconfig.json extends
  26        .devcontainer/devcontainer.json node feature
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)