### PR TITLE
Add a weather page that answers what to wear

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 node_modules/
 test-results/
 playwright-report/
+
+# Core dumps, e.g. from a headless browser killed mid-test.
+core.*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,10 +36,32 @@ cargo build --release --target x86_64-unknown-linux-gnu   # Production build for
 
 - **`src/main.rs`** - Entry point, server setup with graceful shutdown, and all integration tests
 - **`src/router.rs`** - Route definitions and security header middleware (CSP, HSTS, X-Frame-Options, etc.)
-- **`src/handlers/`** - Request handlers for each route (echo, uuid, sha, slot, icloud-private-relay, index)
+- **`src/handlers/`** - Request handlers for each route (echo, uuid, sha, slot, icloud-private-relay, weather, index)
 - **`src/extractors.rs`** - Proxy header handling (X-Forwarded-For, X-Forwarded-Proto) with trust verification for localhost
 - **`src/config.rs`** - Environment-based configuration (PORT, SERVER_HOSTNAME)
-- **`src/services/`** - External service integrations (iCloud Private Relay IP detection)
+- **`src/services/`** - External service integrations (iCloud Private Relay IP detection, Open-Meteo weather)
+- **`src/units.rs`** - Typed quantities (`Temperature`, `TemperatureDelta`, `Speed`), each storing one canonical unit
+- **`src/comfort.rs`** - Steadman apparent temperature plus a radiation budget, giving felt temperature in sun and in shade
+- **`src/scale.rs`** - The personal 0-10 comfort scale the weather page leads with
+- **`src/locations.rs`** - Committed saved locations for the weather page
+
+### The weather page
+
+`/weather` answers "what do I wear, and do I need a layer for later". It is
+rendered server-side in one pass and leads with a 0-10 comfort score rather than
+a temperature; degrees are kept as supporting detail.
+
+- Felt temperature is Steadman's apparent temperature in its radiation form, so
+  it stays informative between 50-80°F where consumer "feels like" values fall
+  back to raw air temperature. See the module docs in `src/comfort.rs`.
+- The sun/shade pair needs direct and diffuse solar radiation separately, which
+  is why the data source is Open-Meteo — see `src/services/open_meteo.rs` for
+  the comparison against the alternatives. No API key is involved.
+- Forecasts are cached in memory per location for ten minutes. There is no
+  database: saved locations are committed to `src/locations.rs`, and the browser
+  keeps any personal default in `localStorage`.
+- The page's CSP is `default-src 'self'`, so there is no inline script or style.
+  The score tooltips are CSS-only (`:hover` plus `:focus` for touch).
 
 ### Templates and Static Files
 

--- a/e2e/weather.spec.ts
+++ b/e2e/weather.spec.ts
@@ -1,0 +1,137 @@
+import { test, expect } from "@playwright/test";
+
+// These hit the live Open-Meteo API through the server, so they assert on
+// structure and labels rather than on any particular temperature. The server
+// caches each location for ten minutes, so only the first test pays for the
+// upstream call.
+test.describe("Weather", () => {
+  test("loads successfully", async ({ page }) => {
+    const response = await page.goto("/weather");
+    expect(response?.status()).toBe(200);
+  });
+
+  test("defaults to the Inner Sunset", async ({ page }) => {
+    await page.goto("/weather");
+    await expect(
+      page.getByRole("heading", { name: "Inner Sunset" }),
+    ).toBeVisible();
+  });
+
+  test("leads with a single 0-10 score for the day", async ({ page }) => {
+    await page.goto("/weather");
+    await expect(
+      page.locator(".weather-hero-value .weather-probe-trigger"),
+    ).toHaveText(/^\d\.\d$/);
+    await expect(page.locator(".weather-hero-share")).toHaveText(
+      /for \d+% of it/,
+    );
+  });
+
+  test("shows the cool and warm bounds either side of it", async ({ page }) => {
+    await page.goto("/weather");
+    await expect(page.getByText("coolest, out of the sun")).toBeVisible();
+    await expect(page.getByText(/warmest, \d+ [AP]M/)).toBeVisible();
+    await expect(
+      page.locator(".weather-bound-value .weather-probe-trigger"),
+    ).toHaveCount(2);
+  });
+
+  test("tells you what to wear", async ({ page }) => {
+    await page.goto("/weather");
+    await expect(page.getByText(/^Dress for \d\.\d —/)).toBeVisible();
+  });
+
+  test("colours each score by how it feels", async ({ page }) => {
+    await page.goto("/weather");
+    const chip = page.locator(".weather-hero .weather-probe-trigger").first();
+    await expect(chip).toHaveClass(/weather-feel-([0-9]|10)\b/);
+  });
+
+  test("a score reveals the data behind it", async ({ page }) => {
+    await page.goto("/weather");
+    const tip = page.locator(".weather-hero .weather-probe-tip").first();
+    await expect(tip).toBeHidden();
+
+    // Tap is the mobile path; it focuses the button, which opens the tooltip.
+    await page.locator(".weather-hero .weather-probe-trigger").first().click();
+    await expect(tip).toBeVisible();
+    await expect(tip).toContainText(/air \d+° · wind \d+ mph/);
+  });
+
+  test("explains what the 0-10 scale means", async ({ page }) => {
+    await page.goto("/weather");
+    await page.getByText("What the 0 to 10 means").click();
+    await expect(page.locator(".weather-key-list li")).toHaveCount(11);
+    await expect(page.getByText("perfect · about 60°")).toBeVisible();
+  });
+
+  test("shows a sun and shade reading for every hour", async ({ page }) => {
+    await page.goto("/weather");
+    await expect(
+      page.getByRole("columnheader", { name: "In sun" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("columnheader", { name: "In shade" }),
+    ).toBeVisible();
+    expect(
+      await page.locator(".weather-hours tbody tr").count(),
+    ).toBeGreaterThan(6);
+  });
+
+  test("marks sunset in the hourly view", async ({ page }) => {
+    await page.goto("/weather");
+    await expect(page.locator(".weather-row-sunset")).toContainText(
+      /Sunset \d+:\d\d [AP]M/,
+    );
+  });
+
+  test("compares today against yesterday", async ({ page }) => {
+    await page.goto("/weather");
+    await expect(
+      page.getByRole("heading", { name: "Against yesterday" }),
+    ).toBeVisible();
+    await expect(
+      page.getByRole("rowheader", { name: "Typical feel" }),
+    ).toBeVisible();
+  });
+
+  test("is honest about the resolution of the data", async ({ page }) => {
+    await page.goto("/weather");
+    await expect(page.locator(".weather-resolution")).toContainText(
+      /grid point used here is [\d.]+ mi/,
+    );
+  });
+
+  test("switches to a pinned location", async ({ page }) => {
+    await page.goto("/weather");
+    await page.getByRole("link", { name: "Financial District" }).click();
+
+    await expect(page).toHaveURL("/weather?loc=fidi");
+    await expect(
+      page.getByRole("heading", { name: "Financial District" }),
+    ).toBeVisible();
+  });
+
+  test("the search form submits a place name", async ({ page }) => {
+    await page.goto("/weather");
+    await page.locator("#q").fill("Portland");
+    await page.getByRole("button", { name: "Look up" }).click();
+
+    // Only the URL is asserted: resolving the name needs the geocoding service
+    // as well as the forecast, and a flaky upstream should not fail the suite.
+    await expect(page).toHaveURL(/[?&]q=Portland/);
+  });
+
+  test("opens an arbitrary location by coordinates", async ({ page }) => {
+    await page.goto("/weather?lat=45.5234&lon=-122.6762&name=Portland");
+    await expect(page.getByRole("heading", { name: "Portland" })).toBeVisible();
+  });
+
+  test("shows in navigation header with active class", async ({ page }) => {
+    await page.goto("/weather");
+    const weatherLink = page.locator('nav a[href="/weather"]');
+    await expect(weatherLink).toHaveClass(
+      "header-nav-link header-nav-link-active",
+    );
+  });
+});

--- a/src/comfort.rs
+++ b/src/comfort.rs
@@ -1,0 +1,450 @@
+//! Felt temperature: what the air actually does to a person standing in it.
+//!
+//! # Why not the API's "feels like"
+//!
+//! Consumer `apparent_temperature` fields are a switch between Rothfusz heat
+//! index (above ~80°F) and the JAG/TI wind chill (below ~50°F), with raw air
+//! temperature in between. In the 50-80°F band this page exists for, they carry
+//! no information at all, and none of them know whether the sun is out.
+//!
+//! # The model
+//!
+//! Steadman's apparent temperature, radiation form, as published by the
+//! Australian Bureau of Meteorology:
+//!
+//! ```text
+//! AT = Ta + 0.348e - 0.70v + 0.70Q/(v + 10) - 4.25
+//! ```
+//!
+//! `Ta` is air temperature (°C), `e` water vapour pressure (hPa), `v` wind
+//! speed at 10 m (m/s), and `Q` the net radiation absorbed per unit area of
+//! body surface (W/m²). It is continuous over the whole mild range, it takes
+//! wind and humidity as first-class inputs, and — unlike every other common
+//! index — it has an explicit radiation term, which is what lets one model
+//! produce both halves of the sun/shade pair.
+//!
+//! Steadman, R.G. (1994), *Norms of apparent temperature in Australia*, Aust.
+//! Met. Mag. 43, 1-16.
+//!
+//! # Getting Q
+//!
+//! Steadman does not say how to obtain `Q`, so it is built here as the standard
+//! human radiation budget for a standing person, expressed relative to a
+//! radiatively neutral environment (everything at air temperature). That
+//! reference point matters: it makes `Q ≈ 0` for an overcast night, so the
+//! radiation form degrades gracefully into Steadman's non-radiation form
+//! (`Ta + 0.33e - 0.70v - 4.00`) rather than diverging from it.
+//!
+//! ```text
+//! Q = a_sw * (f_p * DNI + f_eff * (F_sky * DHI + F_grd * albedo * G)) + L_net
+//! ```
+//!
+//! * `f_p`, the projected area factor of a standing body, is Fanger's (1970)
+//!   azimuth-averaged form `0.308 cos(b(1 - b²/48000))` for solar elevation
+//!   `b` in degrees. It is why noon sun adds less than the raw beam suggests:
+//!   an upright person presents very little area to an overhead sun.
+//! * `f_eff = 0.725` is the fraction of body surface that exchanges radiation
+//!   with the environment at all, and `F_sky = F_grd = 0.5` the sky/ground view
+//!   factors of an upright cylinder.
+//! * `L_net` is the longwave term: a clear sky is far colder than the air and
+//!   pulls real heat off a body, an overcast one radiates back at roughly air
+//!   temperature. Sky emissivity is Brunt's `0.605 + 0.048√e`, blended toward
+//!   the black-body value 1.0 by cloud fraction. This is the part that makes a
+//!   clear evening feel colder than a cloudy one at the same temperature.
+//!
+//! The sun and shade figures differ only in `Q`: shade drops the direct beam
+//! and reflects off shaded ground (diffuse only) instead of sunlit ground.
+//!
+//! # Sun, shade, and the day you actually get
+//!
+//! Those two are the bounds, not the expectation. The sun figure assumes the
+//! beam is on you, which under heavy cloud is a place you may not stand all
+//! day — cloud cover is not the same thing as shade, and reporting the sunlit
+//! ceiling as "how it feels" overstates an overcast day badly. [`Felt::typical`]
+//! is the two blended by how much sky is actually clear: cloud cover is the
+//! fraction of sky covered, so `1 - cloud` approximates the chance the sun's
+//! disc is on you at any given moment. Under a solid deck it collapses onto the
+//! shade figure; under a clear sky it is the sun figure.
+//!
+//! Inputs and outputs are typed ([`Temperature`], [`Speed`]) so a caller cannot
+//! feed Fahrenheit or mph into formulas calibrated for neither. Inside a single
+//! formula the values are plain `f64`: the physics mixes units by design, and
+//! wrapping every intermediate would obscure it.
+
+use crate::units::{Speed, Temperature};
+
+/// Stefan-Boltzmann constant (W/m²/K⁴).
+const STEFAN_BOLTZMANN: f64 = 5.670_374_419e-8;
+
+/// Shortwave absorptivity of a clothed body.
+const SHORTWAVE_ABSORPTIVITY: f64 = 0.7;
+
+/// Longwave emissivity of skin and clothing.
+const LONGWAVE_EMISSIVITY: f64 = 0.95;
+
+/// Fraction of body surface that exchanges radiation with the environment
+/// rather than with itself. 0.725 is the standing value.
+const EFFECTIVE_AREA_FRACTION: f64 = 0.725;
+
+/// View factors of an upright body: half sky, half ground.
+const SKY_VIEW_FACTOR: f64 = 0.5;
+const GROUND_VIEW_FACTOR: f64 = 0.5;
+
+/// Reflectance of ordinary ground cover. Concrete and asphalt bracket this.
+const GROUND_ALBEDO: f64 = 0.2;
+
+/// One hour of weather, in the units this model works in.
+#[derive(Clone, Copy, Debug)]
+pub struct Conditions {
+    /// Air temperature at 2 m.
+    pub air: Temperature,
+    /// Relative humidity at 2 m (%).
+    pub relative_humidity: f64,
+    /// Wind speed at 10 m. Steadman's `v` is a 10 m wind.
+    pub wind: Speed,
+    /// Direct normal irradiance: beam strength facing the sun (W/m²).
+    pub direct_normal: f64,
+    /// Direct irradiance on a horizontal plane (W/m²). Only used to recover the
+    /// solar elevation, via `direct_horizontal = DNI · sin(elevation)`.
+    pub direct_horizontal: f64,
+    /// Diffuse (sky) irradiance on a horizontal plane (W/m²).
+    pub diffuse: f64,
+    /// Cloud cover (%).
+    pub cloud_cover: f64,
+}
+
+/// How one hour feels: the two bounds, and the expectation between them.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Felt {
+    /// With the beam directly on you. The ceiling, not the forecast.
+    pub sun: Temperature,
+    /// Out of the beam. The floor for as long as the sun is up.
+    pub shade: Temperature,
+    /// The two weighted by how much of the sky is clear — what the hour is
+    /// actually likely to feel like.
+    pub typical: Temperature,
+}
+
+/// Water vapour pressure (hPa) via the Magnus form Steadman's users assume.
+fn vapour_pressure_hpa(air_c: f64, relative_humidity: f64) -> f64 {
+    let saturation = 6.105 * (17.27 * air_c / (237.7 + air_c)).exp();
+    (relative_humidity.clamp(0.0, 100.0) / 100.0) * saturation
+}
+
+/// Fanger's projected area factor for a standing person, averaged over azimuth.
+///
+/// Peaks at 0.308 with the sun on the horizon and falls to ~0.08 overhead.
+fn projected_area_factor(solar_elevation_deg: f64) -> f64 {
+    let elevation = solar_elevation_deg.clamp(0.0, 90.0);
+    0.308
+        * (elevation * (1.0 - elevation * elevation / 48_000.0))
+            .to_radians()
+            .cos()
+}
+
+/// Recovers solar elevation from the two direct-radiation components.
+///
+/// Saves asking for a separate solar position: the API already reports the beam
+/// both normal to the sun and projected onto the horizontal.
+fn solar_elevation_deg(direct_normal: f64, direct_horizontal: f64) -> f64 {
+    if direct_normal <= 0.0 {
+        return 0.0;
+    }
+    (direct_horizontal / direct_normal)
+        .clamp(0.0, 1.0)
+        .asin()
+        .to_degrees()
+}
+
+/// Net longwave exchange (W/m²), relative to a body in an environment at air
+/// temperature. Negative under a clear sky, ~0 under overcast.
+fn net_longwave(air_c: f64, vapour_hpa: f64, cloud_cover: f64) -> f64 {
+    let clear_sky_emissivity = (0.605 + 0.048 * vapour_hpa.max(0.0).sqrt()).clamp(0.0, 1.0);
+    let cloud_fraction = (cloud_cover / 100.0).clamp(0.0, 1.0);
+    // Cloud base sits near air temperature, so overcast radiates as a black body.
+    let sky_emissivity = clear_sky_emissivity + (1.0 - clear_sky_emissivity) * cloud_fraction;
+
+    let air_k = air_c + 273.15;
+    EFFECTIVE_AREA_FRACTION
+        * LONGWAVE_EMISSIVITY
+        * STEFAN_BOLTZMANN
+        * air_k.powi(4)
+        * SKY_VIEW_FACTOR
+        * (sky_emissivity - 1.0)
+}
+
+/// Shortwave absorbed per unit body surface (W/m²).
+///
+/// `beam` is already projected onto the body; `reflecting` is the irradiance
+/// reaching the ground the body sees, which is the global figure in the open
+/// and the diffuse figure in a shadow.
+fn absorbed_shortwave(beam: f64, diffuse: f64, reflecting: f64) -> f64 {
+    SHORTWAVE_ABSORPTIVITY
+        * (beam
+            + EFFECTIVE_AREA_FRACTION
+                * (SKY_VIEW_FACTOR * diffuse + GROUND_VIEW_FACTOR * GROUND_ALBEDO * reflecting))
+}
+
+/// Steadman's apparent temperature, radiation form (°C).
+fn apparent_temperature_c(air_c: f64, vapour_hpa: f64, wind_ms: f64, net_radiation: f64) -> f64 {
+    air_c + 0.348 * vapour_hpa - 0.70 * wind_ms + 0.70 * net_radiation / (wind_ms + 10.0) - 4.25
+}
+
+/// Felt temperature in direct sun and in shade for one hour.
+pub fn felt(conditions: &Conditions) -> Felt {
+    let air_c = conditions.air.celsius();
+    let vapour = vapour_pressure_hpa(air_c, conditions.relative_humidity);
+    let wind = conditions.wind.meters_per_second().max(0.0);
+    let longwave = net_longwave(air_c, vapour, conditions.cloud_cover);
+
+    let elevation = solar_elevation_deg(conditions.direct_normal, conditions.direct_horizontal);
+    let beam = projected_area_factor(elevation) * conditions.direct_normal.max(0.0);
+    let diffuse = conditions.diffuse.max(0.0);
+    let global = conditions.direct_horizontal.max(0.0) + diffuse;
+
+    // In shade the beam is gone and the ground you see is shaded too, so it can
+    // only bounce back the diffuse component.
+    let sun_radiation = absorbed_shortwave(beam, diffuse, global) + longwave;
+    let shade_radiation = absorbed_shortwave(0.0, diffuse, diffuse) + longwave;
+
+    let sun = apparent_temperature_c(air_c, vapour, wind, sun_radiation);
+    let shade = apparent_temperature_c(air_c, vapour, wind, shade_radiation);
+    let clear_sky = 1.0 - (conditions.cloud_cover / 100.0).clamp(0.0, 1.0);
+
+    Felt {
+        sun: Temperature::from_celsius(sun),
+        shade: Temperature::from_celsius(shade),
+        typical: Temperature::from_celsius(shade + clear_sky * (sun - shade)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A clear San Francisco afternoon: mild air, stiff sea breeze, full sun.
+    fn sunny_sf() -> Conditions {
+        Conditions {
+            air: Temperature::from_celsius(18.0),
+            relative_humidity: 70.0,
+            wind: Speed::from_meters_per_second(6.0),
+            direct_normal: 850.0,
+            direct_horizontal: 736.0, // 850 · sin(60°)
+            diffuse: 100.0,
+            cloud_cover: 0.0,
+        }
+    }
+
+    /// The same air, under a marine layer.
+    fn overcast_sf() -> Conditions {
+        Conditions {
+            direct_normal: 0.0,
+            direct_horizontal: 0.0,
+            diffuse: 180.0,
+            cloud_cover: 100.0,
+            ..sunny_sf()
+        }
+    }
+
+    fn night() -> Conditions {
+        Conditions {
+            direct_normal: 0.0,
+            direct_horizontal: 0.0,
+            diffuse: 0.0,
+            ..sunny_sf()
+        }
+    }
+
+    #[test]
+    fn vapour_pressure_matches_magnus_formula() {
+        // 20°C saturates near 23.4 hPa, so half that at 50% humidity.
+        let saturated = vapour_pressure_hpa(20.0, 100.0);
+        assert!((saturated - 23.4).abs() < 0.3, "{saturated}");
+        assert!((vapour_pressure_hpa(20.0, 50.0) - saturated / 2.0).abs() < 1e-9);
+        assert_eq!(vapour_pressure_hpa(20.0, 0.0), 0.0);
+    }
+
+    #[test]
+    fn projected_area_peaks_at_the_horizon_and_shrinks_overhead() {
+        assert!((projected_area_factor(0.0) - 0.308).abs() < 1e-9);
+        assert!(projected_area_factor(90.0) < 0.09);
+        // Monotonically decreasing as the sun climbs.
+        for elevation in 0..90 {
+            let low = projected_area_factor(f64::from(elevation));
+            let high = projected_area_factor(f64::from(elevation) + 1.0);
+            assert!(high < low, "not decreasing at {elevation}°");
+        }
+    }
+
+    #[test]
+    fn projected_area_is_clamped_outside_the_real_range() {
+        assert_eq!(projected_area_factor(-10.0), projected_area_factor(0.0));
+        assert_eq!(projected_area_factor(120.0), projected_area_factor(90.0));
+    }
+
+    #[test]
+    fn solar_elevation_is_recovered_from_the_beam_components() {
+        assert!((solar_elevation_deg(1000.0, 500.0) - 30.0).abs() < 1e-9);
+        assert!((solar_elevation_deg(1000.0, 1000.0) - 90.0).abs() < 1e-9);
+        // Rounding in the source data must not produce a NaN from asin.
+        assert!((solar_elevation_deg(800.0, 801.0) - 90.0).abs() < 1e-9);
+        assert_eq!(solar_elevation_deg(0.0, 0.0), 0.0);
+    }
+
+    #[test]
+    fn clear_sky_pulls_heat_off_a_body_and_overcast_does_not() {
+        let vapour = vapour_pressure_hpa(18.0, 70.0);
+        let clear = net_longwave(18.0, vapour, 0.0);
+        let overcast = net_longwave(18.0, vapour, 100.0);
+        assert!((-45.0..-15.0).contains(&clear), "{clear}");
+        assert!(overcast.abs() < 1e-9, "{overcast}");
+        assert!(net_longwave(18.0, vapour, 50.0) > clear);
+    }
+
+    #[test]
+    fn sun_and_shade_are_identical_after_dark() {
+        let felt = felt(&night());
+        assert_eq!(felt.sun, felt.shade);
+        assert_eq!(felt.typical, felt.shade);
+        assert_eq!((felt.sun - felt.shade).fahrenheit(), 0.0);
+    }
+
+    #[test]
+    fn a_solid_overcast_makes_the_typical_hour_a_shaded_one() {
+        // The case that made this necessary: a New York afternoon under 95%
+        // cloud was reporting the full-sun ceiling as how the day would feel.
+        let socked_in = Conditions {
+            cloud_cover: 95.0,
+            ..sunny_sf()
+        };
+        let felt = felt(&socked_in);
+        assert!(
+            (felt.typical - felt.shade).fahrenheit().abs() < 1.0,
+            "typical {:?} should sit on the shade figure {:?}",
+            felt.typical,
+            felt.shade
+        );
+        assert!(felt.sun > felt.typical);
+    }
+
+    #[test]
+    fn a_clear_sky_makes_the_typical_hour_a_sunlit_one() {
+        let felt = felt(&sunny_sf()); // 0% cloud
+        assert_eq!(felt.typical, felt.sun);
+    }
+
+    #[test]
+    fn typical_always_sits_between_the_two_bounds() {
+        for cloud in 0..=100 {
+            let felt = felt(&Conditions {
+                cloud_cover: f64::from(cloud),
+                ..sunny_sf()
+            });
+            assert!(
+                felt.typical >= felt.shade && felt.typical <= felt.sun,
+                "{cloud}% cloud put typical outside the pair"
+            );
+        }
+    }
+
+    #[test]
+    fn radiation_form_agrees_with_steadmans_shade_formula_at_night() {
+        // With no shortwave and no clear-sky loss, the radiation form should
+        // land within a fraction of a degree of AT = Ta + 0.33e - 0.70v - 4.00.
+        let conditions = Conditions {
+            cloud_cover: 100.0,
+            ..night()
+        };
+        let vapour = vapour_pressure_hpa(conditions.air.celsius(), conditions.relative_humidity);
+        let non_radiative = Temperature::from_celsius(
+            conditions.air.celsius() + 0.33 * vapour
+                - 0.70 * conditions.wind.meters_per_second()
+                - 4.00,
+        );
+        assert!((felt(&conditions).shade - non_radiative).fahrenheit().abs() < 0.9);
+    }
+
+    #[test]
+    fn full_sun_opens_a_real_gap_over_shade() {
+        let felt = felt(&sunny_sf());
+        let gap = (felt.sun - felt.shade).fahrenheit();
+        // The whole premise of the page: a mild, windy, sunny day is two days.
+        assert!((8.0..16.0).contains(&gap), "sun/shade gap was {gap}°F");
+        let air = Temperature::from_celsius(18.0);
+        assert!(felt.sun > air);
+        assert!(felt.shade < air);
+    }
+
+    #[test]
+    fn overcast_leaves_almost_no_gap() {
+        let felt = felt(&overcast_sf());
+        assert!((felt.sun - felt.shade).fahrenheit().abs() < 1.0);
+    }
+
+    #[test]
+    fn the_model_stays_informative_in_the_mild_band() {
+        // Identical air temperature, four different days. A consumer
+        // "feels like" would return 64°F for all four.
+        let calm_cloudy = Conditions {
+            wind: Speed::from_meters_per_second(1.0),
+            ..overcast_sf()
+        };
+        let windy_cloudy = overcast_sf();
+        let calm_sunny = Conditions {
+            wind: Speed::from_meters_per_second(1.0),
+            ..sunny_sf()
+        };
+        let windy_sunny = sunny_sf();
+
+        let spread = (felt(&calm_sunny).sun - felt(&windy_cloudy).shade).fahrenheit();
+        assert!(spread > 15.0, "mild-band spread was only {spread}°F");
+
+        assert!(felt(&calm_cloudy).shade > felt(&windy_cloudy).shade);
+        assert!(felt(&calm_sunny).sun > felt(&windy_sunny).sun);
+    }
+
+    #[test]
+    fn wind_and_humidity_both_move_the_answer() {
+        let base = overcast_sf();
+        let windier = Conditions {
+            wind: Speed::from_meters_per_second(base.wind.meters_per_second() + 5.0),
+            ..base
+        };
+        let drier = Conditions {
+            relative_humidity: 20.0,
+            ..base
+        };
+        assert!(felt(&windier).shade < felt(&base).shade);
+        assert!(felt(&drier).shade < felt(&base).shade);
+    }
+
+    #[test]
+    fn noon_sun_is_gentler_on_a_standing_body_than_afternoon_sun() {
+        // Same beam strength, different elevation: the projected area factor
+        // means an overhead sun lands on less of a standing person.
+        let overhead = Conditions {
+            direct_horizontal: 850.0, // elevation 90°
+            ..sunny_sf()
+        };
+        let low = Conditions {
+            direct_horizontal: 425.0, // elevation 30°
+            ..sunny_sf()
+        };
+        assert!(felt(&low).sun > felt(&overhead).sun);
+    }
+
+    #[test]
+    fn absurd_inputs_do_not_produce_nan() {
+        let broken = Conditions {
+            air: Temperature::from_celsius(-60.0),
+            relative_humidity: 150.0,
+            wind: Speed::from_meters_per_second(-3.0),
+            direct_normal: -10.0,
+            direct_horizontal: -10.0,
+            diffuse: -10.0,
+            cloud_cover: 300.0,
+        };
+        let felt = felt(&broken);
+        assert!(felt.sun.celsius().is_finite() && felt.shade.celsius().is_finite());
+    }
+}

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -7,6 +7,7 @@ mod private_relay;
 mod sha;
 mod slot;
 mod uuid;
+mod weather;
 
 pub use echo::echo;
 pub use index::index;
@@ -15,3 +16,4 @@ pub use private_relay::icloud_private_relay;
 pub use sha::sha;
 pub use slot::slot;
 pub use uuid::uuid_route;
+pub use weather::weather;

--- a/src/handlers/weather.rs
+++ b/src/handlers/weather.rs
@@ -1,0 +1,1679 @@
+//! Weather page: what to wear, and whether to carry a layer.
+//!
+//! Everything is rendered server-side in one pass so the page is readable the
+//! moment it arrives. The only client-side work is remembering which location
+//! was last chosen.
+
+use askama::Template;
+use askama_web::WebTemplate;
+use axum::extract::{OriginalUri, Query};
+use axum::http::header::{self, HeaderValue};
+use axum::response::{IntoResponse, Response};
+use serde::Deserialize;
+
+use crate::comfort::{self, Conditions, Felt};
+use crate::helpers::urlencode;
+use crate::locations;
+use crate::scale::{self, Score};
+use crate::services::open_meteo::{self, Day, Forecast, Hour, Place};
+use crate::units::{Speed, Temperature};
+
+/// How long a browser may reuse the page. Comfortably inside the upstream
+/// cache window, and short enough that a reload before leaving is current.
+const CACHE_CONTROL: &str = "public, max-age=300";
+
+// ==================== Query ====================
+
+/// Strings rather than typed numbers so a hand-mangled URL falls back to home
+/// instead of returning a bare 400 from the extractor.
+#[derive(Deserialize)]
+pub struct WeatherQuery {
+    /// Slug of a pinned location.
+    loc: Option<String>,
+    /// Free-text place search.
+    q: Option<String>,
+    lat: Option<String>,
+    lon: Option<String>,
+    name: Option<String>,
+}
+
+/// A resolved place, however it was asked for.
+struct Target {
+    name: String,
+    detail: String,
+    latitude: f64,
+    longitude: f64,
+    /// Query string that reproduces this target, e.g. `loc=fidi`.
+    param: String,
+    /// Slug if this is a pinned location, for highlighting the shortcut row.
+    pin: Option<String>,
+}
+
+impl Target {
+    fn from_pin(location: &'static locations::Location) -> Self {
+        Target {
+            name: location.name.to_owned(),
+            detail: location.detail.to_owned(),
+            latitude: location.latitude,
+            longitude: location.longitude,
+            param: format!("loc={}", location.slug),
+            pin: Some(location.slug.to_owned()),
+        }
+    }
+
+    fn from_place(place: &Place) -> Self {
+        Target {
+            name: place.name.clone(),
+            detail: place.detail.clone(),
+            latitude: place.latitude,
+            longitude: place.longitude,
+            param: place_param(place),
+            pin: None,
+        }
+    }
+}
+
+/// The canonical link for a searched place: coordinates plus a display name, so
+/// the URL is stable and does not re-run the search on every load.
+fn place_param(place: &Place) -> String {
+    coordinate_param(place.latitude, place.longitude, &place.name)
+}
+
+fn coordinate_param(latitude: f64, longitude: f64, name: &str) -> String {
+    format!(
+        "lat={latitude:.4}&lon={longitude:.4}&name={}",
+        urlencode(name)
+    )
+}
+
+/// Resolves the query into a place, plus any other candidates worth offering.
+async fn resolve(query: &WeatherQuery) -> (Target, Vec<Alternate>, Option<String>) {
+    if let (Some(latitude), Some(longitude)) = (
+        query
+            .lat
+            .as_ref()
+            .and_then(|value| value.parse::<f64>().ok()),
+        query
+            .lon
+            .as_ref()
+            .and_then(|value| value.parse::<f64>().ok()),
+    ) {
+        if (-90.0..=90.0).contains(&latitude) && (-180.0..=180.0).contains(&longitude) {
+            let name = query
+                .name
+                .clone()
+                .filter(|name| !name.trim().is_empty())
+                .unwrap_or_else(|| format!("{latitude:.3}, {longitude:.3}"));
+            return (
+                Target {
+                    param: coordinate_param(latitude, longitude, &name),
+                    detail: format!("{latitude:.4}, {longitude:.4}"),
+                    name,
+                    latitude,
+                    longitude,
+                    pin: None,
+                },
+                Vec::new(),
+                None,
+            );
+        }
+    }
+
+    if let Some(search) = query
+        .q
+        .as_ref()
+        .map(|query| query.trim())
+        .filter(|query| !query.is_empty())
+    {
+        return match open_meteo::geocode(search).await {
+            Ok(places) => {
+                let target = Target::from_place(&places[0]);
+                // Everything after the best match becomes a "did you mean".
+                let alternates = places
+                    .iter()
+                    .skip(1)
+                    .map(|place| Alternate {
+                        label: if place.detail.is_empty() {
+                            place.name.clone()
+                        } else {
+                            format!("{}, {}", place.name, place.detail)
+                        },
+                        href: format!("/weather?{}", place_param(place)),
+                    })
+                    .collect();
+                (target, alternates, None)
+            }
+            Err(err) => (
+                Target::from_pin(locations::home()),
+                Vec::new(),
+                Some(err.to_string()),
+            ),
+        };
+    }
+
+    let pin = query
+        .loc
+        .as_deref()
+        .and_then(locations::find)
+        .unwrap_or_else(locations::home);
+    (Target::from_pin(pin), Vec::new(), None)
+}
+
+// ==================== Local time helpers ====================
+//
+// Open-Meteo is asked for `timezone=auto`, so every timestamp arrives as a
+// naive local ISO 8601 string in the location's own clock. That makes ordering,
+// grouping and "which hour is it there" pure string work, and keeps a date
+// library out of the dependency list.
+
+/// `2026-08-02T14:00` -> `2026-08-02`.
+fn date_of(iso: &str) -> &str {
+    iso.get(..10).unwrap_or(iso)
+}
+
+/// `2026-08-02T14:00` -> `14`.
+fn hour_of(iso: &str) -> Option<u32> {
+    iso.get(11..13)?.parse().ok()
+}
+
+/// `2026-08-02T14:30` -> `14.5`, for placing markers between hour columns.
+fn fractional_hour(iso: &str) -> Option<f64> {
+    let hour = f64::from(hour_of(iso)?);
+    let minute = f64::from(iso.get(14..16)?.parse::<u32>().ok()?);
+    Some(hour + minute / 60.0)
+}
+
+/// `14` -> `2 PM`.
+fn hour_label(hour: u32) -> String {
+    let (display, suffix) = twelve_hour(hour);
+    format!("{display} {suffix}")
+}
+
+/// `14` -> `2p`, for the chart's cramped axis.
+fn short_hour_label(hour: u32) -> String {
+    let (display, suffix) = twelve_hour(hour);
+    format!("{display}{}", if suffix == "AM" { 'a' } else { 'p' })
+}
+
+/// `2026-08-02T20:17` -> `8:17 PM`.
+fn clock_label(iso: &str) -> String {
+    let Some(hour) = hour_of(iso) else {
+        return iso.to_owned();
+    };
+    let minute = iso.get(14..16).unwrap_or("00");
+    let (display, suffix) = twelve_hour(hour);
+    format!("{display}:{minute} {suffix}")
+}
+
+fn twelve_hour(hour: u32) -> (u32, &'static str) {
+    match hour {
+        0 => (12, "AM"),
+        1..=11 => (hour, "AM"),
+        12 => (12, "PM"),
+        _ => (hour - 12, "PM"),
+    }
+}
+
+// ==================== Derived hourly data ====================
+
+/// One hour, with the comfort model already applied.
+#[derive(Clone, Copy)]
+struct Modelled<'a> {
+    raw: &'a Hour,
+    hour: u32,
+    felt: Felt,
+}
+
+impl<'a> Modelled<'a> {
+    fn new(raw: &'a Hour) -> Option<Self> {
+        Some(Modelled {
+            hour: hour_of(&raw.time)?,
+            felt: comfort::felt(&Conditions {
+                air: raw.air,
+                relative_humidity: raw.relative_humidity,
+                wind: raw.wind,
+                direct_normal: raw.direct_normal,
+                direct_horizontal: raw.direct_horizontal,
+                diffuse: raw.diffuse,
+                cloud_cover: raw.cloud_cover,
+            }),
+            raw,
+        })
+    }
+
+    /// Whether there is enough beam for "in sun" to mean anything.
+    fn sunlit(&self) -> bool {
+        self.raw.direct_normal > 5.0
+    }
+
+    /// A score with everything behind it, for the numbers that stand alone.
+    ///
+    /// The hourly table needs no probe: its own row already spells out the air
+    /// temperature, wind, cloud and rain that produced the figure.
+    fn probe(&self, exposure: Exposure) -> Probe {
+        let felt = match exposure {
+            Exposure::Sun => self.felt.sun,
+            Exposure::Shade => self.felt.shade,
+            Exposure::Typical => self.felt.typical,
+        };
+        let score = scale::score(felt);
+        Probe {
+            level: score.level(),
+            score: score.to_string(),
+            label: score.label().to_owned(),
+            degrees: felt.round_fahrenheit(),
+            hour_label: hour_label(self.hour),
+            air_f: self.raw.air.round_fahrenheit(),
+            wind_mph: self.raw.wind.round_miles_per_hour(),
+            humidity: self.raw.relative_humidity.round() as i32,
+            cloud: self.raw.cloud_cover.round() as i32,
+        }
+    }
+}
+
+/// Which reading of an hour a number refers to.
+#[derive(Clone, Copy)]
+enum Exposure {
+    Sun,
+    Shade,
+    /// The sun/shade pair weighted by how much sky is clear.
+    Typical,
+}
+
+/// Every modelled hour belonging to one local date.
+fn hours_on<'a>(forecast: &'a Forecast, date: &str) -> Vec<Modelled<'a>> {
+    forecast
+        .hours
+        .iter()
+        .filter(|hour| date_of(&hour.time) == date)
+        .filter_map(Modelled::new)
+        .collect()
+}
+
+/// The stretch of the day worth showing: an hour before sunrise through a
+/// couple of hours past sunset, which is exactly the window in which the
+/// sun/shade distinction and the evening drop-off matter.
+fn daylight_window(day: &Day) -> (u32, u32) {
+    let start = hour_of(&day.sunrise)
+        .unwrap_or(6)
+        .saturating_sub(1)
+        .clamp(4, 11);
+    let end = (hour_of(&day.sunset).unwrap_or(20) + 2).clamp(15, 23);
+    (start, end)
+}
+
+/// Summary statistics over the visible window.
+struct Extremes {
+    min_shade: Temperature,
+    peak_sun_score: Score,
+    min_shade_score: Score,
+    /// The middle of the day's exposure-weighted hours.
+    typical_score: Score,
+    typical: Temperature,
+    air_high: Temperature,
+    max_wind: Speed,
+    mean_cloud: f64,
+    max_rain_chance: f64,
+    total_rain_inches: f64,
+}
+
+/// The middle value, which shrugs off an hour or two of freak weather in a way
+/// a mean does not.
+fn median(scores: impl Iterator<Item = Score>) -> Option<Score> {
+    let mut sorted: Vec<Score> = scores.collect();
+    sorted.sort_by(|a, b| a.value().partial_cmp(&b.value()).expect("no NaN"));
+    sorted.get(sorted.len() / 2).copied()
+}
+
+fn median_temperature(values: impl Iterator<Item = Temperature>) -> Option<Temperature> {
+    let mut sorted: Vec<Temperature> = values.collect();
+    sorted.sort_by(|a, b| a.partial_cmp(b).expect("no NaN"));
+    sorted.get(sorted.len() / 2).copied()
+}
+
+/// The share of hours that round to the same whole point as `typical`, which is
+/// what lets the page say "8.2, and that is most of the day".
+fn share_near(hours: &[Modelled], typical: Score) -> i32 {
+    if hours.is_empty() {
+        return 0;
+    }
+    let near = hours
+        .iter()
+        .filter(|hour| (scale::score(hour.felt.typical).value() - typical.value()).abs() <= 0.5)
+        .count();
+    (near as f64 / hours.len() as f64 * 100.0).round() as i32
+}
+
+fn extremes(hours: &[Modelled]) -> Option<Extremes> {
+    Some(Extremes {
+        // `reduce` yields None on an empty window, which is the only failure
+        // mode here and short-circuits the whole struct.
+        min_shade: hours
+            .iter()
+            .map(|h| h.felt.shade)
+            .reduce(Temperature::min)?,
+        peak_sun_score: hours
+            .iter()
+            .map(|h| scale::score(h.felt.sun))
+            .reduce(Score::max)?,
+        min_shade_score: hours
+            .iter()
+            .map(|h| scale::score(h.felt.shade))
+            .reduce(Score::min)?,
+        typical_score: median(hours.iter().map(|h| scale::score(h.felt.typical)))?,
+        typical: median_temperature(hours.iter().map(|h| h.felt.typical))?,
+        air_high: hours.iter().map(|h| h.raw.air).reduce(Temperature::max)?,
+        max_wind: hours.iter().map(|h| h.raw.wind).reduce(Speed::max)?,
+        mean_cloud: hours.iter().map(|h| h.raw.cloud_cover).sum::<f64>() / hours.len() as f64,
+        max_rain_chance: hours
+            .iter()
+            .map(|h| h.raw.precipitation_probability)
+            .fold(0.0, f64::max),
+        total_rain_inches: hours.iter().map(|h| h.raw.precipitation_mm).sum::<f64>() / 25.4,
+    })
+}
+
+// ==================== Chart ====================
+
+const CHART_WIDTH: f64 = 320.0;
+const CHART_HEIGHT: f64 = 172.0;
+const PLOT_LEFT: f64 = 26.0;
+const PLOT_RIGHT: f64 = 314.0;
+const PLOT_TOP: f64 = 18.0;
+const PLOT_BOTTOM: f64 = 136.0;
+/// Baseline for the hour labels under the plot.
+const AXIS_LABEL_Y: f64 = 150.0;
+/// Baseline for the sunset caption above the plot.
+const MARKER_LABEL_Y: f64 = 11.0;
+/// Never show a vertical range tighter than this many scale points, or
+/// ordinary noise looks like a dramatic swing.
+const MIN_SCALE_SPAN: f64 = 2.5;
+
+struct GridLine {
+    y: f64,
+    label: i32,
+}
+
+/// A horizontal stripe of the plot, tinted with the colour of one whole point
+/// on the scale. Reading the chart's height against these says what a given
+/// height actually feels like without going back to the axis.
+struct FeelBand {
+    y: f64,
+    height: f64,
+    level: u8,
+}
+
+struct AxisTick {
+    x: f64,
+    label: String,
+}
+
+struct Marker {
+    x: f64,
+    /// Caption position, pulled in from the edges so it cannot overflow.
+    label_x: f64,
+    label: String,
+    /// False when the caption would collide with another marker's.
+    show_label: bool,
+}
+
+/// A whole-day picture of the felt range: the filled band is today's shade-to-
+/// sun spread, the dashed outline is yesterday's.
+struct Chart {
+    width: f64,
+    height: f64,
+    plot_left: f64,
+    plot_right: f64,
+    plot_width: f64,
+    plot_top: f64,
+    plot_bottom: f64,
+    axis_label_y: f64,
+    marker_label_y: f64,
+    grid_label_x: f64,
+    sun_line: String,
+    shade_line: String,
+    yesterday_band: Option<String>,
+    grid: Vec<GridLine>,
+    bands: Vec<FeelBand>,
+    ticks: Vec<AxisTick>,
+    sunset: Option<Marker>,
+    now: Option<Marker>,
+}
+
+/// One decimal is plenty for SVG geometry and keeps the markup small.
+fn round1(value: f64) -> f64 {
+    (value * 10.0).round() / 10.0
+}
+
+struct ChartInput<'a> {
+    today: &'a [Modelled<'a>],
+    yesterday: &'a [Modelled<'a>],
+    window: (u32, u32),
+    sunset: &'a str,
+    now: &'a str,
+}
+
+impl Chart {
+    fn build(input: &ChartInput) -> Option<Chart> {
+        let (start, end) = input.window;
+        if end <= start || input.today.len() < 2 {
+            return None;
+        }
+
+        // Both days share one scale, otherwise the comparison lies. The axis is
+        // the 0-10 comfort scale, the same units as the headline.
+        let mut lowest = f64::MAX;
+        let mut highest = f64::MIN;
+        for hour in input.today.iter().chain(input.yesterday.iter()) {
+            lowest = lowest.min(scale::score(hour.felt.shade).value());
+            highest = highest.max(scale::score(hour.felt.sun).value());
+        }
+        let mut floor = (lowest - 0.3).floor();
+        let mut ceiling = (highest + 0.3).ceil();
+        if ceiling - floor < MIN_SCALE_SPAN {
+            let padding = (MIN_SCALE_SPAN - (ceiling - floor)) / 2.0;
+            floor -= padding;
+            ceiling += padding;
+        }
+        floor = floor.max(0.0);
+        ceiling = ceiling.min(10.0);
+
+        let span = f64::from(end - start);
+        let x_at = |hour: f64| {
+            PLOT_LEFT
+                + ((hour - f64::from(start)) / span).clamp(0.0, 1.0) * (PLOT_RIGHT - PLOT_LEFT)
+        };
+        let y_at = |degrees: f64| {
+            PLOT_BOTTOM - ((degrees - floor) / (ceiling - floor)) * (PLOT_BOTTOM - PLOT_TOP)
+        };
+
+        let trace = |hours: &[Modelled], pick: fn(&Modelled) -> Temperature| {
+            hours
+                .iter()
+                .map(|hour| {
+                    format!(
+                        "{},{}",
+                        round1(x_at(f64::from(hour.hour))),
+                        round1(y_at(scale::score(pick(hour)).value()))
+                    )
+                })
+                .collect::<Vec<String>>()
+                .join(" ")
+        };
+        // Sun edge left to right, shade edge back again: one closed outline.
+        // Only yesterday needs it -- today is drawn as two live edges.
+        let band = |hours: &[Modelled]| {
+            let mut shade: Vec<&str> = Vec::new();
+            let shade_trace = trace(hours, |hour| hour.felt.shade);
+            shade.extend(shade_trace.split(' ').rev());
+            format!("{} {}", trace(hours, |hour| hour.felt.sun), shade.join(" "))
+        };
+
+        let whole_points = floor.ceil() as i32..=ceiling.floor() as i32;
+        let grid = whole_points
+            .clone()
+            .map(|point| GridLine {
+                y: round1(y_at(f64::from(point))),
+                label: point,
+            })
+            .collect();
+
+        // One stripe per whole point, clipped to the plot.
+        let bands = whole_points
+            .map(|point| {
+                let top = y_at(f64::from(point) + 0.5).max(PLOT_TOP);
+                let bottom = y_at(f64::from(point) - 0.5).min(PLOT_BOTTOM);
+                FeelBand {
+                    y: round1(top),
+                    height: round1((bottom - top).max(0.0)),
+                    level: point.clamp(0, 10) as u8,
+                }
+            })
+            .collect();
+
+        let ticks = (start..=end)
+            .filter(|hour| hour % 3 == 0)
+            .map(|hour| AxisTick {
+                x: round1(x_at(f64::from(hour))),
+                label: short_hour_label(hour),
+            })
+            .collect();
+
+        // Captions are half a caption-width in from either edge so long labels
+        // like "sunset 8:17 PM" stay inside the viewBox.
+        const CAPTION_INSET: f64 = 46.0;
+        let marker_at = |iso: &str, label: String| {
+            fractional_hour(iso)
+                .filter(|hour| *hour >= f64::from(start) && *hour <= f64::from(end))
+                .map(|hour| {
+                    let x = round1(x_at(hour));
+                    Marker {
+                        x,
+                        label_x: round1(x.clamp(CAPTION_INSET, CHART_WIDTH - CAPTION_INSET)),
+                        label,
+                        show_label: true,
+                    }
+                })
+        };
+
+        let sunset = marker_at(
+            input.sunset,
+            format!("sunset {}", clock_label(input.sunset)),
+        );
+        let now = marker_at(input.now, "now".to_owned()).map(|mut marker| {
+            // Late in the day "now" and "sunset" sit on top of each other;
+            // sunset is the one that changes the decision, so it wins.
+            marker.show_label = sunset
+                .as_ref()
+                .is_none_or(|other| (other.label_x - marker.label_x).abs() > 70.0);
+            marker
+        });
+
+        Some(Chart {
+            width: CHART_WIDTH,
+            height: CHART_HEIGHT,
+            plot_left: PLOT_LEFT,
+            plot_right: PLOT_RIGHT,
+            plot_width: PLOT_RIGHT - PLOT_LEFT,
+            plot_top: PLOT_TOP,
+            plot_bottom: PLOT_BOTTOM,
+            axis_label_y: AXIS_LABEL_Y,
+            marker_label_y: MARKER_LABEL_Y,
+            grid_label_x: PLOT_LEFT - 4.0,
+            sun_line: trace(input.today, |hour| hour.felt.sun),
+            shade_line: trace(input.today, |hour| hour.felt.shade),
+            // A handful of stray hours would draw a misleading stub, so only
+            // show yesterday when it covers a comparable stretch of the day.
+            yesterday_band: (input.yesterday.len() >= input.today.len() / 2)
+                .then(|| band(input.yesterday)),
+            grid,
+            bands,
+            ticks,
+            sunset,
+            now,
+        })
+    }
+}
+
+// ==================== View model ====================
+
+struct Pin {
+    name: String,
+    detail: String,
+    href: String,
+    active: bool,
+}
+
+struct Alternate {
+    label: String,
+    href: String,
+}
+
+/// One row of the printed scale key.
+struct KeyStep {
+    level: u8,
+    label: &'static str,
+    degrees: i32,
+}
+
+/// A score plus everything that produced it, revealed on hover or tap.
+///
+/// Only used where the raw numbers are not already on screen. The hourly table
+/// needs no probe: its own row spells out air, wind, cloud and rain already.
+struct Probe {
+    /// 0-10, the colour band this reading sits in.
+    level: u8,
+    score: String,
+    label: String,
+    degrees: i32,
+    hour_label: String,
+    air_f: i32,
+    wind_mph: i32,
+    humidity: i32,
+    cloud: i32,
+}
+
+struct HourRow {
+    label: String,
+    sun_level: u8,
+    shade_level: u8,
+    sun_score: String,
+    shade_score: String,
+    sun_f: i32,
+    shade_f: i32,
+    /// Blank when there is no sun to be in, so the table does not print two
+    /// identical numbers and imply a choice that does not exist.
+    has_sun: bool,
+    air_f: i32,
+    wind_mph: i32,
+    cloud: i32,
+    rain_chance: i32,
+    is_now: bool,
+    past: bool,
+    /// The sun goes down between this row and the next.
+    sunset_follows: bool,
+}
+
+struct NowRow {
+    label: String,
+    sun: Probe,
+    shade: Probe,
+    has_sun: bool,
+    air_f: i32,
+    wind_mph: i32,
+    versus_yesterday: Option<String>,
+}
+
+struct Comparison {
+    label: String,
+    today: String,
+    yesterday: String,
+    delta: String,
+    /// Direction, for colouring: `up`, `down` or `flat`.
+    direction: &'static str,
+}
+
+struct Report {
+    // Headline: the range and swing, not the air temperature.
+    /// `the rest of today` or `today`, depending on how much is left of it.
+    headline_scope: &'static str,
+    /// What the rest of the day mostly feels like, and how much of it that
+    /// covers. This is the headline; the bounds are context for it.
+    typical: Probe,
+    typical_share: i32,
+    /// The coldest it gets out of the sun, and the warmest it gets at all.
+    low: Probe,
+    high: Probe,
+    high_hour: String,
+    swing_f: i32,
+    verdict: Vec<String>,
+    now: Option<NowRow>,
+
+    chart: Option<Chart>,
+
+    hours: Vec<HourRow>,
+    sunrise_label: String,
+    sunset_label: String,
+
+    // Deliberately secondary.
+    air_high_f: i32,
+    air_low_f: i32,
+    rain_chance: i32,
+    rain_total_in: String,
+
+    comparisons: Vec<Comparison>,
+    has_yesterday: bool,
+
+    grid_distance_mi: String,
+    grid_elevation_ft: i32,
+    timezone: String,
+    updated_label: String,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "weather.html.jinja")]
+struct WeatherTemplate {
+    path: String,
+    place_name: String,
+    place_detail: String,
+    place_param: String,
+    search_query: String,
+    pins: Vec<Pin>,
+    alternates: Vec<Alternate>,
+    report: Option<Report>,
+    error: Option<String>,
+    key: Vec<KeyStep>,
+}
+
+// ==================== Report assembly ====================
+
+fn signed(difference: f64, unit: &str) -> String {
+    let rounded = difference.round() as i32;
+    match rounded {
+        0 => "same".to_owned(),
+        _ if rounded > 0 => format!("+{rounded}{unit}"),
+        _ => format!("{rounded}{unit}"),
+    }
+}
+
+fn direction_of(difference: f64) -> &'static str {
+    match difference.round() as i32 {
+        0 => "flat",
+        rounded if rounded > 0 => "up",
+        _ => "down",
+    }
+}
+
+fn row(label: &str, today: f64, yesterday: f64, unit: &str) -> Comparison {
+    Comparison {
+        label: label.to_owned(),
+        today: format!("{}{unit}", today.round() as i32),
+        yesterday: format!("{}{unit}", yesterday.round() as i32),
+        delta: signed(today - yesterday, unit),
+        direction: direction_of(today - yesterday),
+    }
+}
+
+fn temperature_row(label: &str, today: Temperature, yesterday: Temperature) -> Comparison {
+    row(label, today.fahrenheit(), yesterday.fahrenheit(), "\u{b0}")
+}
+
+/// A comparison on the 0-10 scale, which needs its own formatting: whole
+/// degrees would hide a change of half a point.
+fn score_row(label: &str, today: Score, yesterday: Score) -> Comparison {
+    let difference = today.value() - yesterday.value();
+    Comparison {
+        label: label.to_owned(),
+        today: today.to_string(),
+        yesterday: yesterday.to_string(),
+        delta: match format!("{difference:+.1}").as_str() {
+            "+0.0" | "-0.0" => "same".to_owned(),
+            signed => signed.to_owned(),
+        },
+        direction: match (difference * 10.0).round() as i32 {
+            0 => "flat",
+            tenths if tenths > 0 => "up",
+            _ => "down",
+        },
+    }
+}
+
+/// The answer to the question the page exists for, in at most four sentences.
+///
+/// Written in the 0-10 scale with degrees in brackets: the score is the
+/// decision, the temperature is the evidence for it.
+fn verdict(today: &Extremes, peak: Score, peak_hour: &str, sunset_label: &str) -> Vec<String> {
+    let typical = today.typical_score;
+    let low = today.min_shade_score;
+
+    let mut sentences = vec![format!(
+        "Dress for {typical} \u{2014} {} ({}\u{b0}).",
+        typical.label(),
+        today.typical.round_fahrenheit()
+    )];
+
+    // Only worth a sentence when the peak lands somewhere else on the scale.
+    if peak.value() - typical.value() >= 0.4 {
+        sentences.push(format!(
+            "Around {peak_hour}, out in the open, it reaches {peak} \u{2014} {}.",
+            peak.label()
+        ));
+    }
+
+    let shade_clause = format!(
+        "Out of the sun, and once it goes at {sunset_label}, it eases to {low} ({}\u{b0})",
+        today.min_shade.round_fahrenheit()
+    );
+    sentences.push(if peak.value() - low.value() >= 1.0 {
+        format!("{shade_clause} \u{2014} enough of a spread to carry a layer for.")
+    } else {
+        format!("{shade_clause}.")
+    });
+
+    if today.max_wind.miles_per_hour() >= 18.0 {
+        sentences.push(format!(
+            "Wind peaks near {} mph, which is most of why the shade reads colder than the air.",
+            today.max_wind.round_miles_per_hour()
+        ));
+    } else if today.max_rain_chance >= 40.0 {
+        sentences.push(format!(
+            "Rain reaches {}% at its likeliest \u{2014} bring the shell rather than the sweater.",
+            today.max_rain_chance.round() as i32
+        ));
+    }
+
+    sentences
+}
+
+fn build_report(forecast: &Forecast, target: &Target) -> Option<Report> {
+    let today_date = date_of(&forecast.current_time);
+    let today_index = forecast
+        .days
+        .iter()
+        .position(|day| day.date == today_date)?;
+    let today = &forecast.days[today_index];
+    let yesterday = today_index
+        .checked_sub(1)
+        .map(|index| &forecast.days[index]);
+
+    let (start, end) = daylight_window(today);
+    let in_window = |hour: &Modelled| hour.hour >= start && hour.hour <= end;
+
+    let all_today = hours_on(forecast, &today.date);
+    let visible: Vec<Modelled> = all_today.iter().copied().filter(in_window).collect();
+    // Fall back to whatever the day has, rather than rendering an empty page.
+    let visible = if visible.is_empty() {
+        all_today
+    } else {
+        visible
+    };
+
+    let all_yesterday = yesterday
+        .map(|day| hours_on(forecast, &day.date))
+        .unwrap_or_default();
+    let yesterday_visible: Vec<Modelled> =
+        all_yesterday.iter().copied().filter(in_window).collect();
+
+    let now_hour = hour_of(&forecast.current_time);
+    let sunset_hour = hour_of(&today.sunset).unwrap_or(20);
+    let sunset_label = clock_label(&today.sunset);
+
+    // The headline answers "what do I put on now", so it covers the hours still
+    // ahead. Including hours already gone would let a cold dawn set the advice
+    // for someone walking out at nine. Before dawn, or with almost nothing left
+    // of the day, the whole window is the more useful answer.
+    let remaining: Vec<Modelled> = now_hour
+        .map(|now| {
+            visible
+                .iter()
+                .copied()
+                .filter(|hour| hour.hour >= now)
+                .collect()
+        })
+        .unwrap_or_default();
+    let looking_ahead = remaining.len() >= 3;
+    let decision = if looking_ahead { &remaining } else { &visible };
+
+    let today_extremes = extremes(decision)?;
+    // The day-versus-day table compares whole days, so it keeps the full window.
+    let full_day = extremes(&visible)?;
+    let yesterday_extremes = extremes(&yesterday_visible);
+
+    let hours: Vec<HourRow> = visible
+        .iter()
+        .map(|hour| HourRow {
+            label: hour_label(hour.hour),
+            sun_level: scale::score(hour.felt.sun).level(),
+            shade_level: scale::score(hour.felt.shade).level(),
+            sun_score: scale::score(hour.felt.sun).to_string(),
+            shade_score: scale::score(hour.felt.shade).to_string(),
+            sun_f: hour.felt.sun.round_fahrenheit(),
+            shade_f: hour.felt.shade.round_fahrenheit(),
+            has_sun: hour.sunlit(),
+            air_f: hour.raw.air.round_fahrenheit(),
+            wind_mph: hour.raw.wind.round_miles_per_hour(),
+            cloud: hour.raw.cloud_cover.round() as i32,
+            rain_chance: hour.raw.precipitation_probability.round() as i32,
+            is_now: now_hour == Some(hour.hour),
+            past: now_hour.is_some_and(|now| hour.hour < now),
+            sunset_follows: hour.hour == sunset_hour,
+        })
+        .collect();
+
+    let now = now_hour
+        .and_then(|hour| visible.iter().find(|modelled| modelled.hour == hour))
+        .map(|current| NowRow {
+            label: clock_label(&forecast.current_time),
+            sun: current.probe(Exposure::Sun),
+            shade: current.probe(Exposure::Shade),
+            has_sun: current.sunlit(),
+            air_f: current.raw.air.round_fahrenheit(),
+            wind_mph: current.raw.wind.round_miles_per_hour(),
+            versus_yesterday: yesterday_visible
+                .iter()
+                .find(|previous| previous.hour == current.hour)
+                .map(|previous| {
+                    let difference = current.felt.shade - previous.felt.shade;
+                    match difference.round_fahrenheit() {
+                        0 => "same as this time yesterday".to_owned(),
+                        degrees => format!(
+                            "{}\u{b0} {} than this time yesterday",
+                            degrees.abs(),
+                            if degrees > 0 { "warmer" } else { "colder" }
+                        ),
+                    }
+                }),
+        });
+
+    let comparisons = yesterday_extremes
+        .as_ref()
+        .map(|previous| {
+            vec![
+                score_row(
+                    "Typical feel",
+                    full_day.typical_score,
+                    previous.typical_score,
+                ),
+                score_row(
+                    "Coldest, out of the sun",
+                    full_day.min_shade_score,
+                    previous.min_shade_score,
+                ),
+                score_row(
+                    "Peak in direct sun",
+                    full_day.peak_sun_score,
+                    previous.peak_sun_score,
+                ),
+                temperature_row(
+                    "Air temperature, high",
+                    full_day.air_high,
+                    previous.air_high,
+                ),
+                row(
+                    "Strongest wind",
+                    full_day.max_wind.miles_per_hour(),
+                    previous.max_wind.miles_per_hour(),
+                    " mph",
+                ),
+                row(
+                    "Cloud cover, daytime mean",
+                    full_day.mean_cloud,
+                    previous.mean_cloud,
+                    "%",
+                ),
+            ]
+        })
+        .unwrap_or_default();
+
+    let chart = Chart::build(&ChartInput {
+        today: &visible,
+        yesterday: &yesterday_visible,
+        window: (start, end),
+        sunset: &today.sunset,
+        now: &forecast.current_time,
+    });
+
+    // The headline numbers each belong to a specific hour, and the probe shows
+    // which one and what the air was doing at the time.
+    let coldest = decision
+        .iter()
+        .min_by(|a, b| a.felt.shade.partial_cmp(&b.felt.shade).expect("no NaN"))?;
+    // The peak is the exposure-weighted hour, not the sunlit ceiling: under a
+    // solid overcast that ceiling is a place nobody actually stands.
+    let warmest = decision
+        .iter()
+        .max_by(|a, b| a.felt.typical.partial_cmp(&b.felt.typical).expect("no NaN"))?;
+    // A real hour near the middle, so the headline number has data behind it.
+    let representative = decision.iter().min_by(|a, b| {
+        let distance = |hour: &Modelled| {
+            (scale::score(hour.felt.typical).value() - today_extremes.typical_score.value()).abs()
+        };
+        distance(a).partial_cmp(&distance(b)).expect("no NaN")
+    })?;
+    let swing_f = warmest.felt.typical.round_fahrenheit() - coldest.felt.shade.round_fahrenheit();
+
+    Some(Report {
+        headline_scope: if looking_ahead {
+            "the rest of today"
+        } else {
+            "today"
+        },
+        typical: representative.probe(Exposure::Typical),
+        typical_share: share_near(decision, today_extremes.typical_score),
+        low: coldest.probe(Exposure::Shade),
+        high: warmest.probe(Exposure::Typical),
+        high_hour: hour_label(warmest.hour),
+        // Derived from the rounded pair rather than rounded separately, so the
+        // swing always equals the two numbers printed beside it.
+        swing_f,
+        verdict: verdict(
+            &today_extremes,
+            scale::score(warmest.felt.typical),
+            &hour_label(warmest.hour),
+            &sunset_label,
+        ),
+        now,
+        chart,
+        hours,
+        sunrise_label: clock_label(&today.sunrise),
+        sunset_label,
+        air_high_f: today.high.round_fahrenheit(),
+        air_low_f: today.low.round_fahrenheit(),
+        rain_chance: full_day.max_rain_chance.round() as i32,
+        rain_total_in: format!("{:.2}", full_day.total_rain_inches),
+        comparisons,
+        has_yesterday: yesterday_extremes.is_some(),
+        grid_distance_mi: format!(
+            "{:.1}",
+            open_meteo::distance_miles(
+                target.latitude,
+                target.longitude,
+                forecast.grid_latitude,
+                forecast.grid_longitude,
+            )
+        ),
+        grid_elevation_ft: (forecast.grid_elevation * 3.280_84).round() as i32,
+        timezone: forecast.timezone_abbreviation.clone(),
+        updated_label: clock_label(&forecast.current_time),
+    })
+}
+
+// ==================== Handler ====================
+
+pub async fn weather(OriginalUri(uri): OriginalUri, Query(query): Query<WeatherQuery>) -> Response {
+    let (target, alternates, mut error) = resolve(&query).await;
+
+    let report = match open_meteo::forecast(target.latitude, target.longitude).await {
+        Ok(forecast) => {
+            let report = build_report(&forecast, &target);
+            if report.is_none() {
+                error = Some("Open-Meteo returned no usable hours for today.".to_owned());
+            }
+            report
+        }
+        Err(err) => {
+            error = Some(err.to_string());
+            None
+        }
+    };
+
+    let pins = locations::PINNED
+        .iter()
+        .map(|location| Pin {
+            name: location.name.to_owned(),
+            detail: location.detail.to_owned(),
+            href: format!("/weather?loc={}", location.slug),
+            active: target.pin.as_deref() == Some(location.slug),
+        })
+        .collect();
+
+    let page = WeatherTemplate {
+        path: uri.path().to_string(),
+        place_name: target.name,
+        place_detail: target.detail,
+        place_param: target.param,
+        search_query: query.q.unwrap_or_default(),
+        pins,
+        alternates,
+        report,
+        error,
+        key: scale::key()
+            .into_iter()
+            .map(|(level, label, degrees)| KeyStep {
+                level,
+                label,
+                degrees,
+            })
+            .collect(),
+    };
+
+    (
+        [(
+            header::CACHE_CONTROL,
+            HeaderValue::from_static(CACHE_CONTROL),
+        )],
+        page,
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hour(time: &str, air_c: f64, direct_normal: f64) -> Hour {
+        Hour {
+            time: time.to_owned(),
+            air: Temperature::from_celsius(air_c),
+            relative_humidity: 70.0,
+            wind: Speed::from_meters_per_second(5.0),
+            precipitation_mm: 0.0,
+            precipitation_probability: 0.0,
+            cloud_cover: 10.0,
+            direct_normal,
+            // A 58° solar elevation, near enough for a fixture.
+            direct_horizontal: direct_normal * 0.85,
+            diffuse: if direct_normal > 0.0 { 90.0 } else { 0.0 },
+        }
+    }
+
+    /// An ordinary diurnal curve in °C: coldest just before dawn, warmest mid
+    /// afternoon, easing off into the evening but never back to the dawn low.
+    const DIURNAL: [f64; 24] = [
+        14.0, 13.5, 13.0, 12.8, 12.5, 12.3, 12.5, 13.5, 15.0, 17.0, 19.0, 20.5, 21.5, 22.0, 22.5,
+        22.8, 22.5, 22.0, 21.0, 19.5, 18.0, 16.5, 15.5, 14.7,
+    ];
+
+    /// Two days of hourly data: yesterday fogged in, today clear, with the same
+    /// air temperatures on both. That is the case the page exists to tell apart.
+    fn forecast() -> Forecast {
+        let mut hours = Vec::new();
+        for date in ["2026-08-01", "2026-08-02"] {
+            for (clock, air_c) in DIURNAL.iter().enumerate() {
+                let daylight = (9..=19).contains(&clock);
+                let beam = if daylight && date == "2026-08-02" {
+                    850.0
+                } else {
+                    0.0
+                };
+                hours.push(hour(&format!("{date}T{clock:02}:00"), *air_c, beam));
+            }
+        }
+        Forecast {
+            grid_latitude: 37.7561,
+            grid_longitude: -122.4457,
+            grid_elevation: 65.0,
+            timezone_abbreviation: "GMT-7".to_owned(),
+            current_time: "2026-08-02T13:15".to_owned(),
+            hours,
+            days: vec![
+                Day {
+                    date: "2026-08-01".to_owned(),
+                    high: Temperature::from_celsius(22.0),
+                    low: Temperature::from_celsius(12.6),
+                    sunrise: "2026-08-01T06:13".to_owned(),
+                    sunset: "2026-08-01T20:18".to_owned(),
+                },
+                Day {
+                    date: "2026-08-02".to_owned(),
+                    high: Temperature::from_celsius(23.0),
+                    low: Temperature::from_celsius(12.4),
+                    sunrise: "2026-08-02T06:14".to_owned(),
+                    sunset: "2026-08-02T20:17".to_owned(),
+                },
+            ],
+        }
+    }
+
+    fn target() -> Target {
+        Target::from_pin(locations::home())
+    }
+
+    fn report() -> Report {
+        build_report(&forecast(), &target()).expect("report")
+    }
+
+    // ---- time helpers ----
+
+    #[test]
+    fn splits_local_iso_timestamps() {
+        assert_eq!(date_of("2026-08-02T14:00"), "2026-08-02");
+        assert_eq!(hour_of("2026-08-02T14:00"), Some(14));
+        assert_eq!(hour_of("2026-08-02T00:00"), Some(0));
+        assert_eq!(hour_of("garbage"), None);
+        assert_eq!(fractional_hour("2026-08-02T14:30"), Some(14.5));
+        assert_eq!(fractional_hour("nope"), None);
+    }
+
+    #[test]
+    fn formats_twelve_hour_clock_labels() {
+        assert_eq!(hour_label(0), "12 AM");
+        assert_eq!(hour_label(9), "9 AM");
+        assert_eq!(hour_label(12), "12 PM");
+        assert_eq!(hour_label(13), "1 PM");
+        assert_eq!(hour_label(23), "11 PM");
+        assert_eq!(short_hour_label(0), "12a");
+        assert_eq!(short_hour_label(15), "3p");
+        assert_eq!(clock_label("2026-08-02T20:17"), "8:17 PM");
+        assert_eq!(clock_label("2026-08-02T00:05"), "12:05 AM");
+        assert_eq!(clock_label("nonsense"), "nonsense");
+    }
+
+    #[test]
+    fn window_covers_sunrise_through_after_sunset() {
+        let day = &forecast().days[1];
+        assert_eq!(daylight_window(day), (5, 22));
+    }
+
+    #[test]
+    fn window_is_clamped_for_polar_style_days() {
+        let midnight_sun = Day {
+            date: "2026-06-21".to_owned(),
+            high: Temperature::from_celsius(10.0),
+            low: Temperature::from_celsius(4.0),
+            sunrise: "2026-06-21T00:30".to_owned(),
+            sunset: "2026-06-21T23:50".to_owned(),
+        };
+        assert_eq!(daylight_window(&midnight_sun), (4, 23));
+    }
+
+    // ---- report ----
+
+    #[test]
+    fn headline_is_the_felt_range_not_the_air_temperature() {
+        let report = report();
+        assert!(report.high.level > report.low.level);
+        assert_eq!(report.swing_f, report.high.degrees - report.low.degrees);
+        // The felt peak exceeds the air high; that difference is the entire
+        // point of the page.
+        assert!(report.high.degrees > report.air_high_f);
+    }
+
+    #[test]
+    fn the_headline_is_the_typical_hour_not_the_sunlit_ceiling() {
+        let report = report();
+        // Typical sits inside the bounds, and covers a real share of the day.
+        assert!(report.typical.degrees >= report.low.degrees);
+        assert!(report.typical.degrees <= report.high.degrees);
+        assert!(
+            (1..=100).contains(&report.typical_share),
+            "share was {}",
+            report.typical_share
+        );
+        assert!(report.high_hour.ends_with("AM") || report.high_hour.ends_with("PM"));
+    }
+
+    #[test]
+    fn heavy_cloud_pulls_the_headline_down_to_the_shaded_figure() {
+        // The New York case: 95% cloud must not headline the full-sun ceiling.
+        let mut overcast = forecast();
+        for hour in &mut overcast.hours {
+            hour.cloud_cover = 95.0;
+        }
+        let clear = report();
+        let socked_in = build_report(&overcast, &target()).unwrap();
+
+        assert!(
+            socked_in.typical.degrees < clear.typical.degrees,
+            "overcast typical {} should sit below clear {}",
+            socked_in.typical.degrees,
+            clear.typical.degrees
+        );
+        // And it should land near the shaded floor rather than the sun ceiling.
+        let sunlit_ceiling = socked_in
+            .hours
+            .iter()
+            .map(|row| row.sun_f)
+            .max()
+            .expect("hours");
+        assert!(
+            socked_in.high.degrees < sunlit_ceiling,
+            "headline {} should stay under the {}° sunlit ceiling",
+            socked_in.high.degrees,
+            sunlit_ceiling
+        );
+    }
+
+    #[test]
+    fn headline_numbers_are_scale_points_with_their_colour_band() {
+        let report = report();
+        for probe in [&report.typical, &report.low, &report.high] {
+            // One decimal, and a level that matches the number printed.
+            assert!(probe.score.contains('.'), "{}", probe.score);
+            let parsed: f64 = probe.score.parse().unwrap();
+            assert_eq!(probe.level, parsed.round() as u8);
+            assert!(!probe.label.is_empty());
+        }
+    }
+
+    #[test]
+    fn every_headline_number_carries_the_data_behind_it() {
+        // The scale only works if the raw figures are one tap away.
+        let report = report();
+        for probe in [&report.typical, &report.low, &report.high] {
+            assert!(probe.hour_label.ends_with("AM") || probe.hour_label.ends_with("PM"));
+            assert!(probe.degrees > -100 && probe.degrees < 150);
+            assert!(probe.wind_mph >= 0);
+            assert!((0..=100).contains(&probe.humidity));
+            assert!((0..=100).contains(&probe.cloud));
+        }
+    }
+
+    #[test]
+    fn headline_covers_the_hours_still_ahead_not_the_ones_already_gone() {
+        // The fixture's coldest hour is dawn, long before the 1:15 PM "now".
+        // Letting it set the advice would tell someone leaving after lunch to
+        // dress for a morning they already missed.
+        let report = report();
+        assert_eq!(report.headline_scope, "the rest of today");
+
+        let dawn = report
+            .hours
+            .iter()
+            .find(|row| row.label == "5 AM")
+            .unwrap()
+            .shade_f;
+        assert!(
+            report.low.degrees > dawn,
+            "headline low {} should ignore the dawn value {dawn}",
+            report.low.degrees
+        );
+    }
+
+    #[test]
+    fn late_in_the_day_the_headline_falls_back_to_the_whole_day() {
+        let mut nearly_over = forecast();
+        nearly_over.current_time = "2026-08-02T22:00".to_owned();
+        let report = build_report(&nearly_over, &target()).unwrap();
+        assert_eq!(report.headline_scope, "today");
+    }
+
+    #[test]
+    fn the_yesterday_table_still_compares_whole_days() {
+        // Scoping the headline must not quietly scope the comparison too, or
+        // "today vs yesterday" would be an hour count apart.
+        let midday = report();
+        let mut evening = forecast();
+        evening.current_time = "2026-08-02T19:00".to_owned();
+        let evening = build_report(&evening, &target()).unwrap();
+
+        // Midday still has the sunny peak ahead of it; 7 PM does not.
+        assert!(midday.high.degrees > evening.high.degrees);
+        // But both report the same whole-day figures in the comparison table.
+        assert_eq!(midday.comparisons[0].today, evening.comparisons[0].today);
+        assert_eq!(midday.comparisons[1].today, evening.comparisons[1].today);
+    }
+
+    #[test]
+    fn verdict_tells_you_what_to_wear_and_whether_to_carry_a_layer() {
+        let report = report();
+        assert!(report.verdict[0].starts_with("Dress for "));
+        assert!(report.verdict.len() >= 2);
+        assert!(
+            report
+                .verdict
+                .iter()
+                .any(|line| line.contains("once it goes at 8:17 PM")),
+            "{:?}",
+            report.verdict
+        );
+        assert!(
+            report
+                .verdict
+                .iter()
+                .any(|line| line.contains("carry a layer for")),
+            "{:?}",
+            report.verdict
+        );
+    }
+
+    #[test]
+    fn a_sunless_day_says_so_instead_of_promising_a_layer() {
+        let mut fogged = forecast();
+        for hour in &mut fogged.hours {
+            hour.direct_normal = 0.0;
+            hour.direct_horizontal = 0.0;
+            hour.diffuse = 120.0;
+            hour.cloud_cover = 100.0;
+        }
+        let report = build_report(&fogged, &target()).unwrap();
+        // With no beam at all, each hour's sun and shade readings collapse
+        // together, so what range is left is the ordinary daily cycle rather
+        // than anything the sun is doing.
+        for row in &report.hours {
+            assert!(!row.has_sun);
+            assert_eq!(row.sun_f, row.shade_f);
+            assert_eq!(row.sun_score, row.shade_score);
+        }
+        assert!(report.typical.degrees <= report.high.degrees);
+    }
+
+    #[test]
+    fn hourly_rows_cover_the_window_and_mark_now_and_sunset() {
+        let report = report();
+        assert_eq!(report.hours.len(), 18); // 5 AM through 10 PM
+        assert_eq!(report.hours[0].label, "5 AM");
+
+        let now: Vec<&HourRow> = report.hours.iter().filter(|row| row.is_now).collect();
+        assert_eq!(now.len(), 1);
+        assert_eq!(now[0].label, "1 PM");
+
+        let sunset: Vec<&HourRow> = report
+            .hours
+            .iter()
+            .filter(|row| row.sunset_follows)
+            .collect();
+        assert_eq!(sunset.len(), 1);
+        assert_eq!(sunset[0].label, "8 PM");
+
+        assert!(report.hours[0].past);
+        assert!(!report.hours.last().unwrap().past);
+    }
+
+    #[test]
+    fn hours_without_sun_do_not_offer_a_sun_reading() {
+        let report = report();
+        let dawn = &report.hours[0]; // 5 AM
+        assert!(!dawn.has_sun);
+        assert_eq!(dawn.sun_f, dawn.shade_f);
+
+        let noon = report
+            .hours
+            .iter()
+            .find(|row| row.label == "12 PM")
+            .unwrap();
+        assert!(noon.has_sun);
+        assert!(noon.sun_f > noon.shade_f);
+    }
+
+    #[test]
+    fn sunrise_and_sunset_are_surfaced_for_the_hourly_view() {
+        let report = report();
+        assert_eq!(report.sunset_label, "8:17 PM");
+        assert_eq!(report.sunrise_label, "6:14 AM");
+    }
+
+    #[test]
+    fn compares_against_yesterdays_actuals() {
+        let report = report();
+        assert!(report.has_yesterday);
+        assert_eq!(report.comparisons.len(), 6);
+
+        let typical = &report.comparisons[0];
+        assert_eq!(typical.label, "Typical feel");
+        assert_eq!(typical.direction, "up");
+        assert!(typical.delta.starts_with('+'));
+
+        // Same air temperatures both days, so the air row is flat while the
+        // felt rows are not: exactly the "same temperature, different day" case.
+        let air = &report.comparisons[3];
+        assert_eq!(air.direction, "flat");
+        assert_eq!(air.delta, "same");
+    }
+
+    #[test]
+    fn a_day_with_no_yesterday_still_renders() {
+        let mut only_today = forecast();
+        only_today
+            .hours
+            .retain(|hour| date_of(&hour.time) == "2026-08-02");
+        only_today.days.remove(0);
+        let report = build_report(&only_today, &target()).unwrap();
+        assert!(!report.has_yesterday);
+        assert!(report.comparisons.is_empty());
+        assert!(report.chart.expect("chart").yesterday_band.is_none());
+    }
+
+    #[test]
+    fn now_row_reports_the_delta_against_the_same_hour_yesterday() {
+        let now = report().now.expect("now row");
+        assert_eq!(now.label, "1:15 PM");
+        assert!(now.has_sun);
+        assert!(now.sun.degrees > now.shade.degrees);
+        assert!(now.sun.level >= now.shade.level);
+        let versus = now.versus_yesterday.expect("comparison");
+        assert!(versus.ends_with("than this time yesterday"), "{versus}");
+    }
+
+    #[test]
+    fn grid_point_distance_is_reported_for_honesty() {
+        let report = report();
+        // Home is the Inner Sunset; the grid cell used sits a mile or so east.
+        assert_eq!(report.grid_distance_mi, "1.1");
+        assert_eq!(report.grid_elevation_ft, 213);
+    }
+
+    #[test]
+    fn returns_nothing_when_today_is_missing_from_the_response() {
+        let mut stale = forecast();
+        stale.current_time = "2026-09-09T13:00".to_owned();
+        assert!(build_report(&stale, &target()).is_none());
+    }
+
+    // ---- chart ----
+
+    #[test]
+    fn chart_geometry_stays_inside_the_plot_area() {
+        let chart = report().chart.expect("chart");
+        let coordinates = format!(
+            "{} {} {}",
+            chart.sun_line,
+            chart.shade_line,
+            chart.yesterday_band.unwrap_or_default()
+        );
+        for pair in coordinates.split_whitespace() {
+            let (x, y) = pair.split_once(',').expect("x,y pair");
+            let x: f64 = x.parse().unwrap();
+            let y: f64 = y.parse().unwrap();
+            assert!((PLOT_LEFT..=PLOT_RIGHT).contains(&x), "x {x} out of range");
+            assert!(
+                (PLOT_TOP - 0.5..=PLOT_BOTTOM + 0.5).contains(&y),
+                "y {y} out of range"
+            );
+        }
+    }
+
+    #[test]
+    fn yesterdays_outline_closes_back_along_its_shade_edge() {
+        let chart = report().chart.expect("chart");
+        let outline: Vec<&str> = chart
+            .yesterday_band
+            .as_ref()
+            .expect("yesterday")
+            .split(' ')
+            .collect();
+        let today: Vec<&str> = chart.sun_line.split(' ').collect();
+
+        // Sun edge out and shade edge back, so twice the hour count.
+        assert_eq!(outline.len(), today.len() * 2);
+        assert_eq!(outline[0], *outline.last().unwrap_or(&""), "not closed");
+    }
+
+    #[test]
+    fn chart_marks_sunset_and_now() {
+        let chart = report().chart.expect("chart");
+        let sunset = chart.sunset.expect("sunset marker");
+        assert_eq!(sunset.label, "sunset 8:17 PM");
+        let now = chart.now.expect("now marker");
+        assert!(now.x < sunset.x, "now should sit left of sunset");
+        assert!(now.show_label, "midday now-marker has room for its caption");
+    }
+
+    #[test]
+    fn chart_hides_the_now_caption_when_it_would_collide_with_sunset() {
+        let mut dusk = forecast();
+        dusk.current_time = "2026-08-02T20:00".to_owned();
+        let chart = build_report(&dusk, &target())
+            .unwrap()
+            .chart
+            .expect("chart");
+        assert!(!chart.now.expect("now marker").show_label);
+        assert!(chart.sunset.expect("sunset marker").show_label);
+    }
+
+    #[test]
+    fn chart_bands_tile_the_plot_without_escaping_it() {
+        let chart = report().chart.expect("chart");
+        assert!(!chart.bands.is_empty());
+        for band in &chart.bands {
+            assert!((0..=10).contains(&band.level));
+            assert!(band.height >= 0.0);
+            assert!(band.y >= PLOT_TOP - 0.01, "band starts above the plot");
+            assert!(
+                band.y + band.height <= PLOT_BOTTOM + 0.01,
+                "band runs past the bottom of the plot"
+            );
+        }
+        // Bands ascend the scale, so they descend the y axis.
+        for pair in chart.bands.windows(2) {
+            assert!(pair[0].level < pair[1].level);
+            assert!(pair[0].y > pair[1].y);
+        }
+    }
+
+    #[test]
+    fn chart_axis_is_the_comfort_scale_not_degrees() {
+        let chart = report().chart.expect("chart");
+        for line in &chart.grid {
+            assert!(
+                (0..=10).contains(&line.label),
+                "gridline {} is not a scale point",
+                line.label
+            );
+        }
+    }
+
+    #[test]
+    fn chart_shares_one_scale_across_both_days() {
+        let chart = report().chart.expect("chart");
+        assert!(!chart.grid.is_empty());
+        // Gridlines ascend in temperature, so they descend the y axis.
+        for pair in chart.grid.windows(2) {
+            assert!(pair[0].label < pair[1].label);
+            assert!(pair[0].y > pair[1].y);
+        }
+        assert!(chart.ticks.len() >= 4);
+    }
+
+    // ---- query resolution ----
+
+    #[test]
+    fn a_searched_place_round_trips_through_its_own_link() {
+        let place = Place {
+            name: "S\u{e3}o Paulo".to_owned(),
+            detail: "S\u{e3}o Paulo, Brazil".to_owned(),
+            latitude: -23.5475,
+            longitude: -46.6361,
+        };
+        assert_eq!(
+            place_param(&place),
+            "lat=-23.5475&lon=-46.6361&name=S%C3%A3o+Paulo"
+        );
+    }
+
+    fn query(loc: Option<&str>, lat: Option<&str>, lon: Option<&str>) -> WeatherQuery {
+        WeatherQuery {
+            loc: loc.map(str::to_owned),
+            q: None,
+            lat: lat.map(str::to_owned),
+            lon: lon.map(str::to_owned),
+            name: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn an_empty_query_resolves_to_home() {
+        let (target, alternates, error) = resolve(&query(None, None, None)).await;
+        assert_eq!(target.name, "Inner Sunset");
+        assert_eq!(target.param, "loc=inner-sunset");
+        assert!(alternates.is_empty() && error.is_none());
+    }
+
+    #[tokio::test]
+    async fn an_unknown_slug_falls_back_to_home() {
+        let (target, _, error) = resolve(&query(Some("atlantis"), None, None)).await;
+        assert_eq!(target.pin.as_deref(), Some("inner-sunset"));
+        assert!(error.is_none());
+    }
+
+    #[tokio::test]
+    async fn a_pinned_slug_resolves_to_that_neighbourhood() {
+        let (target, _, _) = resolve(&query(Some("fidi"), None, None)).await;
+        assert_eq!(target.name, "Financial District");
+        assert_eq!(target.latitude, 37.7946);
+    }
+
+    #[tokio::test]
+    async fn explicit_coordinates_are_used_verbatim() {
+        let (target, _, _) = resolve(&WeatherQuery {
+            loc: None,
+            q: None,
+            lat: Some("45.5234".to_owned()),
+            lon: Some("-122.6762".to_owned()),
+            name: Some("Portland".to_owned()),
+        })
+        .await;
+        assert_eq!(target.name, "Portland");
+        assert_eq!(target.latitude, 45.5234);
+        assert_eq!(target.param, "lat=45.5234&lon=-122.6762&name=Portland");
+    }
+
+    #[tokio::test]
+    async fn out_of_range_or_unparseable_coordinates_fall_back_to_home() {
+        for (lat, lon) in [("999", "0"), ("abc", "-122.0"), ("37.7", "999")] {
+            let (target, _, _) = resolve(&query(None, Some(lat), Some(lon))).await;
+            assert_eq!(target.pin.as_deref(), Some("inner-sunset"), "{lat},{lon}");
+        }
+    }
+
+    #[test]
+    fn deltas_are_signed_and_directional() {
+        assert_eq!(signed(4.4, "\u{b0}"), "+4\u{b0}");
+        assert_eq!(signed(-4.4, "\u{b0}"), "-4\u{b0}");
+        assert_eq!(signed(0.2, "\u{b0}"), "same");
+        assert_eq!(signed(9.0, " mph"), "+9 mph");
+        assert_eq!(direction_of(3.0), "up");
+        assert_eq!(direction_of(-3.0), "down");
+        assert_eq!(direction_of(0.4), "flat");
+    }
+}

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -4,6 +4,34 @@ use axum::http::header::{self, HeaderMap};
 use multimap::MultiMap;
 use serde_json::Value;
 
+/// Percent-encodes one query-string value.
+///
+/// Hand-rolled because `reqwest`'s `query` feature is not enabled and turning
+/// it on would pull `serde_urlencoded` in for the handful of parameters this
+/// site sends.
+pub fn urlencode(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                encoded.push(byte as char);
+            }
+            b' ' => encoded.push('+'),
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
+/// Builds a `key=value&key=value` query string, encoding each value.
+pub fn query_string(parameters: &[(&str, &str)]) -> String {
+    parameters
+        .iter()
+        .map(|(key, value)| format!("{key}={}", urlencode(value)))
+        .collect::<Vec<String>>()
+        .join("&")
+}
+
 /// Parses a User-Agent string into structured data.
 pub fn get_user_agent(header: &str) -> woothee::parser::WootheeResult<'_> {
     let parser = woothee::parser::Parser::new();
@@ -43,6 +71,28 @@ pub fn pretty_multimap(map: &MultiMap<String, String>) -> serde_json::Map<String
 mod tests {
     use super::*;
     use axum::http::HeaderValue;
+
+    #[test]
+    fn urlencode_escapes_everything_outside_the_unreserved_set() {
+        assert_eq!(urlencode("San Francisco"), "San+Francisco");
+        assert_eq!(urlencode("Ni\u{f1}o"), "Ni%C3%B1o");
+        assert_eq!(urlencode("a-b_c.d~e"), "a-b_c.d~e");
+        assert_eq!(urlencode("a&b=c"), "a%26b%3Dc");
+        assert_eq!(
+            urlencode("temperature_2m,cloud_cover"),
+            "temperature_2m%2Ccloud_cover"
+        );
+        assert_eq!(urlencode(""), "");
+    }
+
+    #[test]
+    fn query_string_joins_and_encodes_each_value() {
+        assert_eq!(
+            query_string(&[("latitude", "37.7596"), ("name", "San Francisco")]),
+            "latitude=37.7596&name=San+Francisco"
+        );
+        assert_eq!(query_string(&[]), "");
+    }
 
     #[test]
     fn requested_html_detects_html_accept_header() {

--- a/src/locations.rs
+++ b/src/locations.rs
@@ -1,0 +1,121 @@
+//! Saved locations, committed to the repo.
+//!
+//! There is no database on this box and no user accounts, so the shortcuts live
+//! here. Anything not on this list is reached by search, and the browser
+//! remembers the last one picked in `localStorage`.
+
+/// A pinned place. Coordinates are a specific corner of the neighbourhood, not
+/// a city centroid — in San Francisco those are different weather.
+pub struct Location {
+    /// URL-safe identifier used as `?loc=`.
+    pub slug: &'static str,
+    /// Short label for the shortcut row.
+    pub name: &'static str,
+    /// What the coordinates actually point at.
+    pub detail: &'static str,
+    pub latitude: f64,
+    pub longitude: f64,
+}
+
+/// The shortcut row, in display order. The first entry is home.
+pub static PINNED: [Location; 3] = [
+    Location {
+        slug: "inner-sunset",
+        name: "Inner Sunset",
+        detail: "Inner Sunset, San Francisco",
+        latitude: 37.7601,
+        longitude: -122.4661,
+    },
+    Location {
+        slug: "fidi",
+        name: "Financial District",
+        detail: "Financial District, San Francisco",
+        latitude: 37.7946,
+        longitude: -122.3999,
+    },
+    Location {
+        slug: "nyc",
+        name: "New York City",
+        detail: "Midtown Manhattan, New York",
+        latitude: 40.7549,
+        longitude: -73.984,
+    },
+];
+
+/// The location shown when nothing else is asked for.
+pub fn home() -> &'static Location {
+    &PINNED[0]
+}
+
+/// Looks up a pinned location by its `?loc=` slug.
+pub fn find(slug: &str) -> Option<&'static Location> {
+    PINNED.iter().find(|location| location.slug == slug)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn home_is_the_inner_sunset() {
+        assert_eq!(home().slug, "inner-sunset");
+        assert_eq!(home().name, "Inner Sunset");
+    }
+
+    #[test]
+    fn every_pin_is_findable_by_slug() {
+        for location in &PINNED {
+            assert_eq!(find(location.slug).map(|f| f.slug), Some(location.slug));
+        }
+        assert!(find("nowhere").is_none());
+    }
+
+    #[test]
+    fn slugs_are_unique_and_url_safe() {
+        let mut slugs: Vec<&str> = PINNED.iter().map(|location| location.slug).collect();
+        slugs.sort_unstable();
+        let count = slugs.len();
+        slugs.dedup();
+        assert_eq!(slugs.len(), count, "duplicate slug");
+
+        for location in &PINNED {
+            assert!(
+                location
+                    .slug
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "{} is not url-safe",
+                location.slug
+            );
+        }
+    }
+
+    #[test]
+    fn coordinates_are_plausible() {
+        for location in &PINNED {
+            assert!(
+                (-90.0..=90.0).contains(&location.latitude),
+                "{}",
+                location.slug
+            );
+            assert!(
+                (-180.0..=180.0).contains(&location.longitude),
+                "{}",
+                location.slug
+            );
+        }
+    }
+
+    #[test]
+    fn the_two_sf_neighbourhoods_are_far_enough_apart_to_differ() {
+        // Inner Sunset and the Financial District resolve to different model
+        // grid cells; if these ever collapse onto one point the page would be
+        // claiming a distinction the data cannot make.
+        let sunset = find("inner-sunset").unwrap();
+        let fidi = find("fidi").unwrap();
+        let degrees = ((sunset.latitude - fidi.latitude).powi(2)
+            + (sunset.longitude - fidi.longitude).powi(2))
+        .sqrt();
+        assert!(degrees > 0.03, "pins are only {degrees}° apart");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,15 @@
 //! Personal website backend server.
 
+mod comfort;
 mod config;
 mod extractors;
 mod handlers;
 mod helpers;
+mod locations;
 mod router;
+mod scale;
 mod services;
+mod units;
 
 use std::net::SocketAddr;
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -12,7 +12,9 @@ use tower_http::set_header::SetResponseHeaderLayer;
 use tower_http::trace::{DefaultMakeSpan, DefaultOnRequest, DefaultOnResponse, TraceLayer};
 use tracing::Level;
 
-use crate::handlers::{echo, icloud_private_relay, index, microwave, sha, slot, uuid_route};
+use crate::handlers::{
+    echo, icloud_private_relay, index, microwave, sha, slot, uuid_route, weather,
+};
 
 /// Returns a 404 Not Found response.
 fn not_found() -> Response {
@@ -40,6 +42,7 @@ pub fn create_app_router() -> Router {
         .route("/icloud-private-relay", get(icloud_private_relay))
         .route("/slot", get(slot))
         .route("/microwave", get(microwave))
+        .route("/weather", get(weather))
         .route("/echo", any(echo))
         .fallback_service(static_files)
         // Security headers

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -1,0 +1,270 @@
+//! A personal 0-10 comfort scale.
+//!
+//! Degrees are a physical measurement, not a decision. 58°F means nothing on
+//! its own — it means something once you know it is a light-jacket day. This
+//! maps felt temperature onto one calibrated number so the page leads with the
+//! answer rather than the measurement.
+//!
+//! The calibration is deliberately personal, not a published index: 5 is the
+//! weather this site's owner likes best, and every other point is described
+//! relative to that. It is committed to the repo for the same reason the home
+//! location is — there is nowhere else to put it.
+//!
+//! Spacing is uneven on purpose. Six degrees to a point through the mild band,
+//! where a couple of degrees genuinely changes what goes on; twenty or more at
+//! the ends, where everything is just "very cold" or "very hot" and the extra
+//! resolution would be false precision.
+//!
+//! The ends are anchored on being unable to go out at all, not merely on being
+//! uncomfortable: 0 is an Alaskan midwinter afternoon, windy and sunless, and
+//! 10 is Singapore in the summer under a clear sky. A day that merely wants
+//! shorts is a 9, not a 10.
+//!
+//! # Prior art
+//!
+//! The shape is not novel, which is reassuring. The ASHRAE 55 / ISO 7730
+//! thermal sensation scale is the same idea: a bounded ordinal scale running
+//! cold to hot with comfortable in the middle, at seven points from -3 to +3.
+//! This is that scale stretched to eleven and shifted so the neutral point is
+//! 5. Fanger's Predicted Mean Vote is the model that puts a population on it,
+//! and UTCI and PET both bin their output into named stress or perception
+//! bands the same way.
+//!
+//! Two things here are deliberately different. Those indices predict the
+//! average vote of a large group at a stated clothing and activity level; this
+//! is calibrated to one person, which is the whole point of a personal site.
+//! And their bands are evenly spaced in degrees, where these are not — see the
+//! spacing note above.
+//!
+//! The presentation owes more to the UV Index: a small bounded number with a
+//! colour per point and an action attached to each.
+
+use crate::units::Temperature;
+use std::fmt;
+
+/// `(felt °F, score)`, ascending. Interpolated between, clamped outside.
+const ANCHORS: [(f64, f64); 11] = [
+    (-25.0, 0.0),
+    (10.0, 1.0),
+    (33.0, 2.0),
+    (45.0, 3.0),
+    (54.0, 4.0),
+    (60.0, 5.0),
+    (66.0, 6.0),
+    (72.0, 7.0),
+    (78.0, 8.0),
+    (88.0, 9.0),
+    (110.0, 10.0),
+];
+
+/// What each whole point means, indexed by the rounded score.
+const LABELS: [&str; 11] = [
+    "dangerous cold, do not go out",
+    "extremely cold, heavy coats",
+    "cold, warm jacket and pants",
+    "cold but tolerable",
+    "cool, light jacket",
+    "perfect",
+    "cool, but the jacket can come off",
+    "warming up, jeans and a t-shirt",
+    "warm, shorts if you like",
+    "hot, shorts and a t-shirt",
+    "dangerous heat, do not go out",
+];
+
+/// A point on the comfort scale, 0 through 10.
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub struct Score(f64);
+
+impl Score {
+    pub fn value(self) -> f64 {
+        self.0
+    }
+
+    /// The description of the nearest whole point.
+    pub fn label(self) -> &'static str {
+        LABELS[self.level() as usize]
+    }
+
+    /// The nearest whole point, which is also the colour band this score sits
+    /// in. The page prints the number beside the colour everywhere, so the
+    /// colour never carries meaning on its own.
+    pub fn level(self) -> u8 {
+        self.0.round().clamp(0.0, 10.0) as u8
+    }
+
+    pub fn min(self, other: Self) -> Self {
+        Score(self.0.min(other.0))
+    }
+
+    pub fn max(self, other: Self) -> Self {
+        Score(self.0.max(other.0))
+    }
+}
+
+/// One decimal, always — `5` and `5.0` should not both appear on the page.
+impl fmt::Display for Score {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:.1}", self.0)
+    }
+}
+
+/// The whole scale, for the key printed on the page. Without it the colours
+/// and the numbers are both undecodable.
+pub fn key() -> Vec<(u8, &'static str, i32)> {
+    ANCHORS
+        .iter()
+        .enumerate()
+        .map(|(level, (degrees, _))| (level as u8, LABELS[level], *degrees as i32))
+        .collect()
+}
+
+/// Places a felt temperature on the scale.
+pub fn score(felt: Temperature) -> Score {
+    let degrees = felt.fahrenheit();
+
+    let (mut low_f, mut low_score) = ANCHORS[0];
+    if degrees <= low_f {
+        return Score(low_score);
+    }
+
+    for (high_f, high_score) in ANCHORS.into_iter().skip(1) {
+        if degrees <= high_f {
+            let position = (degrees - low_f) / (high_f - low_f);
+            return Score(low_score + position * (high_score - low_score));
+        }
+        (low_f, low_score) = (high_f, high_score);
+    }
+
+    Score(10.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn at(fahrenheit: f64) -> Score {
+        score(Temperature::from_celsius((fahrenheit - 32.0) * 5.0 / 9.0))
+    }
+
+    #[test]
+    fn every_anchor_lands_on_its_whole_number() {
+        for (degrees, expected) in ANCHORS {
+            let scored = at(degrees).value();
+            assert!(
+                (scored - expected).abs() < 1e-9,
+                "{degrees}°F scored {scored}, expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn five_is_the_weather_this_site_is_calibrated_for() {
+        assert_eq!(at(60.0).label(), "perfect");
+        assert_eq!(format!("{}", at(60.0)), "5.0");
+    }
+
+    #[test]
+    fn interpolates_between_anchors() {
+        // Halfway from 54°F (4) to 60°F (5).
+        assert!((at(57.0).value() - 4.5).abs() < 1e-9);
+        // A third of the way from 72°F (7) to 78°F (8).
+        assert!((at(74.0).value() - 7.333).abs() < 0.001);
+    }
+
+    #[test]
+    fn clamps_outside_the_scale_instead_of_running_off_it() {
+        assert_eq!(at(-60.0).value(), 0.0);
+        assert_eq!(at(-25.0).value(), 0.0);
+        assert_eq!(at(130.0).value(), 10.0);
+        assert_eq!(at(110.0).value(), 10.0);
+    }
+
+    #[test]
+    fn the_ends_mean_do_not_go_outside() {
+        // An Alaskan midwinter afternoon and a clear Singapore summer day.
+        assert!(at(-25.0).value() <= 0.2, "{}", at(-25.0));
+        assert!(at(108.0).value() >= 9.8, "{}", at(108.0));
+
+        // And an ordinary hot day is emphatically not one of those.
+        let shorts_weather = at(88.0);
+        assert!(
+            (8.5..9.5).contains(&shorts_weather.value()),
+            "88°F scored {shorts_weather}, which should be shorts, not danger"
+        );
+    }
+
+    #[test]
+    fn rises_monotonically_across_the_whole_range() {
+        let mut previous = at(-20.0).value();
+        for degrees in -20..130 {
+            let current = at(f64::from(degrees)).value();
+            assert!(current >= previous, "dipped at {degrees}°F");
+            previous = current;
+        }
+    }
+
+    #[test]
+    fn the_mild_band_has_the_finest_resolution() {
+        // A page for deciding on a layer needs to separate 58° from 64°.
+        let mild = at(66.0).value() - at(60.0).value();
+        let frigid = at(10.0).value() - at(4.0).value();
+        let scorching = at(104.0).value() - at(98.0).value();
+        assert!(mild > frigid * 2.0, "mild {mild} vs frigid {frigid}");
+        assert!(mild > scorching * 2.0, "mild {mild} vs hot {scorching}");
+    }
+
+    #[test]
+    fn labels_describe_what_to_wear_at_each_point() {
+        assert_eq!(at(10.0).label(), "extremely cold, heavy coats");
+        assert_eq!(at(54.0).label(), "cool, light jacket");
+        assert_eq!(at(72.0).label(), "warming up, jeans and a t-shirt");
+        assert_eq!(at(88.0).label(), "hot, shorts and a t-shirt");
+        assert_eq!(at(110.0).label(), "dangerous heat, do not go out");
+    }
+
+    #[test]
+    fn labels_snap_to_the_nearest_whole_point() {
+        assert_eq!(at(61.0).label(), at(60.0).label());
+        // 63°F sits midway between 5 and 6 and rounds up.
+        assert_eq!(at(64.0).label(), at(66.0).label());
+    }
+
+    #[test]
+    fn always_renders_with_one_decimal() {
+        assert_eq!(format!("{}", at(60.0)), "5.0");
+        assert_eq!(format!("{}", at(57.0)), "4.5");
+        assert_eq!(format!("{}", at(-25.0)), "0.0");
+        assert_eq!(format!("{}", at(120.0)), "10.0");
+    }
+
+    #[test]
+    fn the_level_is_the_nearest_whole_point() {
+        assert_eq!(at(60.0).level(), 5);
+        assert_eq!(at(57.0).level(), 5); // 4.5 rounds up
+        assert_eq!(at(-40.0).level(), 0);
+        assert_eq!(at(130.0).level(), 10);
+        for degrees in -20..130 {
+            assert!(at(f64::from(degrees)).level() <= 10);
+        }
+    }
+
+    #[test]
+    fn the_key_covers_every_point_in_order() {
+        let key = key();
+        assert_eq!(key.len(), 11);
+        for (index, (level, label, degrees)) in key.iter().enumerate() {
+            assert_eq!(usize::from(*level), index);
+            assert_eq!(*label, LABELS[index]);
+            assert_eq!(at(f64::from(*degrees)).level(), *level);
+        }
+    }
+
+    #[test]
+    fn extremes_pick_the_right_end() {
+        let cool = at(54.0);
+        let warm = at(78.0);
+        assert_eq!(cool.min(warm), cool);
+        assert_eq!(cool.max(warm), warm);
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,3 +1,4 @@
 //! External service integrations.
 
+pub mod open_meteo;
 pub mod private_relay;

--- a/src/services/open_meteo.rs
+++ b/src/services/open_meteo.rs
@@ -1,0 +1,597 @@
+//! Open-Meteo forecast and geocoding client.
+//!
+//! # Why Open-Meteo
+//!
+//! The sun/shade split needs the beam and the sky components of solar radiation
+//! separately, which rules out most of the free tier:
+//!
+//! * OpenWeatherMap — no radiation components outside the paid Solar Energy API.
+//! * Tomorrow.io / Weatherbit — a single `solarGHI`, no direct/diffuse split.
+//! * NWS api.weather.gov — free and US-only, but publishes no radiation at all.
+//! * Apple WeatherKit — needs a signed key and has no radiation fields.
+//!
+//! Open-Meteo publishes `direct_normal_irradiance`, `direct_radiation` and
+//! `diffuse_radiation` hourly, needs no API key at all (so there is no secret
+//! for this server to hold or rotate), serves history and forecast from one
+//! endpoint via `past_days`, and is free for non-commercial use.
+
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::sync::{Arc, LazyLock, Mutex};
+use std::time::{Duration, Instant};
+
+use crate::helpers::query_string;
+use crate::units::{Speed, Temperature};
+
+/// Upstream is on the critical path of a page load, so fail fast rather than
+/// leave someone waiting at the front door with their coat half on.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(6);
+
+/// Open-Meteo updates hourly data every 15 minutes or so; a shorter window just
+/// spends someone else's quota.
+const CACHE_TTL: Duration = Duration::from_secs(600);
+
+/// Upper bound on distinct locations held in memory. Small because the pinned
+/// list is small and search traffic is one person.
+const CACHE_CAPACITY: usize = 64;
+
+static CLIENT: LazyLock<reqwest::Client> = LazyLock::new(|| {
+    reqwest::Client::builder()
+        .timeout(REQUEST_TIMEOUT)
+        .build()
+        .expect("failed to build http client")
+});
+
+const FORECAST_URL: &str = "https://api.open-meteo.com/v1/forecast";
+const GEOCODING_URL: &str = "https://geocoding-api.open-meteo.com/v1/search";
+
+/// Anything that can stop the page rendering a forecast.
+#[derive(Debug)]
+pub enum Error {
+    Request(reqwest::Error),
+    /// The body arrived but was not the JSON this client expects.
+    Decode(serde_json::Error),
+    /// The response parsed but did not contain a usable day.
+    Incomplete(&'static str),
+    /// A place name that matched nothing.
+    NoSuchPlace(String),
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::Request(err) if err.is_timeout() => {
+                write!(f, "Open-Meteo did not answer in time.")
+            }
+            Error::Request(_) => write!(f, "Could not reach Open-Meteo."),
+            Error::Decode(_) => write!(f, "Open-Meteo sent something unreadable."),
+            Error::Incomplete(what) => write!(f, "Open-Meteo returned no {what}."),
+            Error::NoSuchPlace(query) => write!(f, "No place matched \u{201c}{query}\u{201d}."),
+        }
+    }
+}
+
+impl std::error::Error for Error {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Error::Request(err) => Some(err),
+            Error::Decode(err) => Some(err),
+            Error::Incomplete(_) | Error::NoSuchPlace(_) => None,
+        }
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        Error::Request(err)
+    }
+}
+
+impl From<serde_json::Error> for Error {
+    fn from(err: serde_json::Error) -> Self {
+        Error::Decode(err)
+    }
+}
+
+/// One hour of forecast, in local time.
+#[derive(Clone, Debug)]
+pub struct Hour {
+    /// Local naive ISO 8601, e.g. `2026-08-02T14:00`. Times are already in the
+    /// location's own timezone, so they sort and compare as plain strings and
+    /// this server needs no date library to work with them.
+    pub time: String,
+    pub air: Temperature,
+    pub relative_humidity: f64,
+    /// The request asks for `wind_speed_unit=ms`, which this type pins down.
+    pub wind: Speed,
+    pub precipitation_mm: f64,
+    pub precipitation_probability: f64,
+    pub cloud_cover: f64,
+    pub direct_normal: f64,
+    pub direct_horizontal: f64,
+    pub diffuse: f64,
+}
+
+/// One day's summary, in local time.
+#[derive(Clone, Debug)]
+pub struct Day {
+    /// Local date, `YYYY-MM-DD`.
+    pub date: String,
+    pub high: Temperature,
+    pub low: Temperature,
+    /// Local naive ISO 8601.
+    pub sunrise: String,
+    pub sunset: String,
+}
+
+/// A forecast for one point, as this site uses it.
+#[derive(Clone, Debug)]
+pub struct Forecast {
+    /// Centre of the model grid cell actually used, which is not the point that
+    /// was asked for. Surfaced in the UI so the page cannot overclaim.
+    pub grid_latitude: f64,
+    pub grid_longitude: f64,
+    /// Elevation of that grid cell (m).
+    pub grid_elevation: f64,
+    pub timezone_abbreviation: String,
+    /// Current local time at the location, `YYYY-MM-DDTHH:MM`.
+    pub current_time: String,
+    pub hours: Vec<Hour>,
+    pub days: Vec<Day>,
+}
+
+/// A geocoding hit.
+#[derive(Clone, Debug)]
+pub struct Place {
+    pub name: String,
+    /// Region and country, already assembled for display.
+    pub detail: String,
+    pub latitude: f64,
+    pub longitude: f64,
+}
+
+#[derive(Clone)]
+struct CacheEntry {
+    forecast: Arc<Forecast>,
+    fresh_until: Instant,
+}
+
+static CACHE: LazyLock<Mutex<HashMap<String, CacheEntry>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Cache key. Rounded so that a search result and a pin for the same block
+/// share an entry, and so float formatting cannot produce two keys for one
+/// place.
+fn cache_key(latitude: f64, longitude: f64) -> String {
+    format!("{latitude:.4},{longitude:.4}")
+}
+
+/// Fetches yesterday, today and tomorrow for a point.
+///
+/// Yesterday comes from the same endpoint via `past_days`, which serves the
+/// most recent model analysis for hours that have already happened rather than
+/// the forecast that was live at the time.
+pub async fn forecast(latitude: f64, longitude: f64) -> Result<Arc<Forecast>, Error> {
+    let key = cache_key(latitude, longitude);
+
+    if let Some(entry) = CACHE.lock().expect("cache mutex poisoned").get(&key) {
+        if Instant::now() < entry.fresh_until {
+            return Ok(entry.forecast.clone());
+        }
+    }
+
+    let query = query_string(&[
+        ("latitude", &format!("{latitude:.4}")),
+        ("longitude", &format!("{longitude:.4}")),
+        // Both direct components are requested: the normal one drives the
+        // radiation budget, the horizontal one recovers the solar elevation.
+        (
+            "hourly",
+            "temperature_2m,relative_humidity_2m,precipitation,precipitation_probability,\
+             cloud_cover,wind_speed_10m,direct_radiation,diffuse_radiation,\
+             direct_normal_irradiance",
+        ),
+        (
+            "daily",
+            "temperature_2m_max,temperature_2m_min,sunrise,sunset",
+        ),
+        ("current", "temperature_2m"),
+        ("past_days", "1"),
+        ("forecast_days", "2"),
+        // Everything comes back in the location's own clock time, so a
+        // stateless server never has to know what time it is anywhere.
+        ("timezone", "auto"),
+        ("wind_speed_unit", "ms"),
+    ]);
+
+    let body = CLIENT
+        .get(format!("{FORECAST_URL}?{query}"))
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+
+    let forecast = Arc::new(serde_json::from_slice::<ApiForecast>(&body)?.into_forecast()?);
+
+    let mut cache = CACHE.lock().expect("cache mutex poisoned");
+    let now = Instant::now();
+    cache.retain(|_, entry| now < entry.fresh_until);
+    if cache.len() >= CACHE_CAPACITY {
+        cache.clear();
+    }
+    cache.insert(
+        key,
+        CacheEntry {
+            forecast: forecast.clone(),
+            fresh_until: now + CACHE_TTL,
+        },
+    );
+
+    Ok(forecast)
+}
+
+/// Looks a place name up. Results are ordered by population, so the first is
+/// almost always the intended one and the rest become "did you mean" links.
+pub async fn geocode(query: &str) -> Result<Vec<Place>, Error> {
+    let parameters = query_string(&[
+        ("name", query),
+        ("count", "5"),
+        ("language", "en"),
+        ("format", "json"),
+    ]);
+
+    let body = CLIENT
+        .get(format!("{GEOCODING_URL}?{parameters}"))
+        .send()
+        .await?
+        .error_for_status()?
+        .bytes()
+        .await?;
+
+    let places: Vec<Place> = serde_json::from_slice::<ApiGeocoding>(&body)?
+        .results
+        .unwrap_or_default()
+        .into_iter()
+        .map(ApiPlace::into_place)
+        .collect();
+
+    if places.is_empty() {
+        return Err(Error::NoSuchPlace(query.to_owned()));
+    }
+    Ok(places)
+}
+
+/// Great-circle distance in miles.
+///
+/// Used only to say how far the model's grid cell is from the requested point.
+pub fn distance_miles(
+    from_latitude: f64,
+    from_longitude: f64,
+    to_latitude: f64,
+    to_longitude: f64,
+) -> f64 {
+    const EARTH_RADIUS_MILES: f64 = 3958.8;
+
+    let lat1 = from_latitude.to_radians();
+    let lat2 = to_latitude.to_radians();
+    let delta_lat = (to_latitude - from_latitude).to_radians();
+    let delta_lon = (to_longitude - from_longitude).to_radians();
+
+    let a =
+        (delta_lat / 2.0).sin().powi(2) + lat1.cos() * lat2.cos() * (delta_lon / 2.0).sin().powi(2);
+    2.0 * EARTH_RADIUS_MILES * a.sqrt().clamp(0.0, 1.0).asin()
+}
+
+// ==================== Wire types ====================
+
+#[derive(Deserialize)]
+struct ApiForecast {
+    latitude: f64,
+    longitude: f64,
+    elevation: f64,
+    timezone_abbreviation: String,
+    current: ApiCurrent,
+    hourly: ApiHourly,
+    daily: ApiDaily,
+}
+
+#[derive(Deserialize)]
+struct ApiCurrent {
+    time: String,
+}
+
+/// Open-Meteo returns parallel arrays, with `null` for any hour a model did not
+/// produce. Every numeric series is optional per element for that reason.
+#[derive(Deserialize)]
+struct ApiHourly {
+    time: Vec<String>,
+    temperature_2m: Vec<Option<f64>>,
+    relative_humidity_2m: Vec<Option<f64>>,
+    precipitation: Vec<Option<f64>>,
+    precipitation_probability: Vec<Option<f64>>,
+    cloud_cover: Vec<Option<f64>>,
+    wind_speed_10m: Vec<Option<f64>>,
+    direct_radiation: Vec<Option<f64>>,
+    diffuse_radiation: Vec<Option<f64>>,
+    direct_normal_irradiance: Vec<Option<f64>>,
+}
+
+#[derive(Deserialize)]
+struct ApiDaily {
+    time: Vec<String>,
+    temperature_2m_max: Vec<Option<f64>>,
+    temperature_2m_min: Vec<Option<f64>>,
+    sunrise: Vec<Option<String>>,
+    sunset: Vec<Option<String>>,
+}
+
+#[derive(Deserialize)]
+struct ApiGeocoding {
+    results: Option<Vec<ApiPlace>>,
+}
+
+#[derive(Deserialize)]
+struct ApiPlace {
+    name: String,
+    latitude: f64,
+    longitude: f64,
+    admin1: Option<String>,
+    country: Option<String>,
+}
+
+impl ApiPlace {
+    fn into_place(self) -> Place {
+        let detail = [self.admin1, self.country]
+            .into_iter()
+            .flatten()
+            .collect::<Vec<String>>()
+            .join(", ");
+        Place {
+            name: self.name,
+            detail,
+            latitude: self.latitude,
+            longitude: self.longitude,
+        }
+    }
+}
+
+/// Reads element `index` of an optional series, treating a missing element and
+/// an explicit `null` the same way.
+fn value_at(series: &[Option<f64>], index: usize) -> Option<f64> {
+    series.get(index).copied().flatten()
+}
+
+/// Same, but for series where a gap is harmless. Radiation is zero at night and
+/// precipitation probability is zero when the model has nothing to say.
+fn value_or_zero(series: &[Option<f64>], index: usize) -> f64 {
+    value_at(series, index).unwrap_or(0.0)
+}
+
+impl ApiForecast {
+    fn into_forecast(self) -> Result<Forecast, Error> {
+        let hourly = self.hourly;
+        let hours: Vec<Hour> = (0..hourly.time.len())
+            .filter_map(|i| {
+                // An hour with no temperature, humidity or wind cannot be run
+                // through the comfort model at all, so drop it rather than
+                // invent a value. Everything else defaults to zero.
+                Some(Hour {
+                    time: hourly.time.get(i)?.clone(),
+                    air: Temperature::from_celsius(value_at(&hourly.temperature_2m, i)?),
+                    relative_humidity: value_at(&hourly.relative_humidity_2m, i)?,
+                    wind: Speed::from_meters_per_second(value_at(&hourly.wind_speed_10m, i)?),
+                    precipitation_mm: value_or_zero(&hourly.precipitation, i),
+                    precipitation_probability: value_or_zero(&hourly.precipitation_probability, i),
+                    cloud_cover: value_or_zero(&hourly.cloud_cover, i),
+                    direct_normal: value_or_zero(&hourly.direct_normal_irradiance, i),
+                    direct_horizontal: value_or_zero(&hourly.direct_radiation, i),
+                    diffuse: value_or_zero(&hourly.diffuse_radiation, i),
+                })
+            })
+            .collect();
+
+        if hours.is_empty() {
+            return Err(Error::Incomplete("hourly data"));
+        }
+
+        let daily = self.daily;
+        let days: Vec<Day> = (0..daily.time.len())
+            .filter_map(|i| {
+                Some(Day {
+                    date: daily.time.get(i)?.clone(),
+                    high: Temperature::from_celsius(value_at(&daily.temperature_2m_max, i)?),
+                    low: Temperature::from_celsius(value_at(&daily.temperature_2m_min, i)?),
+                    sunrise: daily.sunrise.get(i)?.clone()?,
+                    sunset: daily.sunset.get(i)?.clone()?,
+                })
+            })
+            .collect();
+
+        if days.is_empty() {
+            return Err(Error::Incomplete("daily data"));
+        }
+
+        Ok(Forecast {
+            grid_latitude: self.latitude,
+            grid_longitude: self.longitude,
+            grid_elevation: self.elevation,
+            timezone_abbreviation: self.timezone_abbreviation,
+            current_time: self.current.time,
+            hours,
+            days,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Trimmed from a real api.open-meteo.com response for San Francisco.
+    const SAMPLE: &str = r#"{
+      "latitude": 37.756073, "longitude": -122.44574, "elevation": 65.0,
+      "utc_offset_seconds": -25200, "timezone": "America/Los_Angeles",
+      "timezone_abbreviation": "GMT-7",
+      "current": {"time": "2026-08-02T13:15", "temperature_2m": 21.5},
+      "hourly": {
+        "time": ["2026-08-01T12:00", "2026-08-01T13:00", "2026-08-02T12:00"],
+        "temperature_2m": [21.1, 21.9, 22.7],
+        "relative_humidity_2m": [71, 71, 63],
+        "precipitation": [0.0, 0.0, 0.1],
+        "precipitation_probability": [0, 0, 12],
+        "cloud_cover": [4, 0, 11],
+        "wind_speed_10m": [3.04, 5.22, 4.1],
+        "direct_radiation": [722.0, 863.0, 700.5],
+        "diffuse_radiation": [160.5, 112.0, 150.0],
+        "direct_normal_irradiance": [841.9, 936.6, 830.0]
+      },
+      "daily": {
+        "time": ["2026-08-01", "2026-08-02"],
+        "temperature_2m_max": [22.0, 23.0],
+        "temperature_2m_min": [12.6, 12.4],
+        "sunrise": ["2026-08-01T06:13", "2026-08-02T06:14"],
+        "sunset": ["2026-08-01T20:18", "2026-08-02T20:17"]
+      }
+    }"#;
+
+    fn sample() -> Forecast {
+        serde_json::from_str::<ApiForecast>(SAMPLE)
+            .unwrap()
+            .into_forecast()
+            .unwrap()
+    }
+
+    #[test]
+    fn parses_a_real_response() {
+        let forecast = sample();
+        assert_eq!(forecast.current_time, "2026-08-02T13:15");
+        assert_eq!(forecast.grid_elevation, 65.0);
+        assert_eq!(forecast.timezone_abbreviation, "GMT-7");
+        assert_eq!(forecast.hours.len(), 3);
+        assert_eq!(forecast.days.len(), 2);
+    }
+
+    #[test]
+    fn keeps_the_grid_point_rather_than_the_requested_point() {
+        // The UI depends on this being the model's coordinates, not ours.
+        let forecast = sample();
+        assert_eq!(forecast.grid_latitude, 37.756073);
+        assert_eq!(forecast.grid_longitude, -122.44574);
+    }
+
+    #[test]
+    fn zips_the_parallel_arrays_in_order() {
+        let forecast = sample();
+        let hour = &forecast.hours[1];
+        assert_eq!(hour.time, "2026-08-01T13:00");
+        assert_eq!(hour.air.celsius(), 21.9);
+        assert_eq!(hour.relative_humidity, 71.0);
+        assert_eq!(hour.wind.meters_per_second(), 5.22);
+        assert_eq!(hour.direct_normal, 936.6);
+        assert_eq!(hour.direct_horizontal, 863.0);
+        assert_eq!(hour.diffuse, 112.0);
+    }
+
+    #[test]
+    fn parses_the_daily_block() {
+        let day = &sample().days[1];
+        assert_eq!(day.date, "2026-08-02");
+        assert_eq!(day.high.celsius(), 23.0);
+        assert_eq!(day.low.celsius(), 12.4);
+        assert_eq!(day.sunset, "2026-08-02T20:17");
+    }
+
+    #[test]
+    fn drops_hours_missing_a_required_field_but_keeps_the_rest() {
+        let json = SAMPLE.replace("[21.1, 21.9, 22.7]", "[21.1, null, 22.7]");
+        let forecast = serde_json::from_str::<ApiForecast>(&json)
+            .unwrap()
+            .into_forecast()
+            .unwrap();
+        assert_eq!(forecast.hours.len(), 2);
+        assert_eq!(forecast.hours[1].time, "2026-08-02T12:00");
+    }
+
+    #[test]
+    fn treats_a_missing_optional_series_value_as_zero() {
+        let json = SAMPLE.replace("[722.0, 863.0, 700.5]", "[722.0, null, 700.5]");
+        let forecast = serde_json::from_str::<ApiForecast>(&json)
+            .unwrap()
+            .into_forecast()
+            .unwrap();
+        assert_eq!(forecast.hours[1].direct_horizontal, 0.0);
+        assert_eq!(forecast.hours[1].air.celsius(), 21.9);
+    }
+
+    #[test]
+    fn rejects_a_response_with_no_usable_hours() {
+        let json = SAMPLE.replace("[21.1, 21.9, 22.7]", "[null, null, null]");
+        let result = serde_json::from_str::<ApiForecast>(&json)
+            .unwrap()
+            .into_forecast();
+        assert!(matches!(result, Err(Error::Incomplete("hourly data"))));
+    }
+
+    #[test]
+    fn rejects_a_response_with_no_usable_days() {
+        let json = SAMPLE.replace(
+            r#""sunset": ["2026-08-01T20:18", "2026-08-02T20:17"]"#,
+            r#""sunset": [null, null]"#,
+        );
+        let result = serde_json::from_str::<ApiForecast>(&json)
+            .unwrap()
+            .into_forecast();
+        assert!(matches!(result, Err(Error::Incomplete("daily data"))));
+    }
+
+    #[test]
+    fn assembles_geocoding_detail_from_whatever_is_present() {
+        let full: ApiPlace = serde_json::from_str(
+            r#"{"name":"Portland","latitude":45.5,"longitude":-122.7,"admin1":"Oregon","country":"United States"}"#,
+        )
+        .unwrap();
+        assert_eq!(full.into_place().detail, "Oregon, United States");
+
+        let sparse: ApiPlace =
+            serde_json::from_str(r#"{"name":"Nowhere","latitude":0.0,"longitude":0.0}"#).unwrap();
+        assert_eq!(sparse.into_place().detail, "");
+    }
+
+    #[test]
+    fn cache_keys_collapse_insignificant_precision() {
+        assert_eq!(
+            cache_key(37.759_600_1, -122.426_9),
+            cache_key(37.759_6, -122.426_899_9)
+        );
+        assert_ne!(cache_key(37.7596, -122.4269), cache_key(37.7601, -122.4661));
+    }
+
+    #[test]
+    fn distance_matches_known_separations() {
+        // Inner Sunset to the Financial District is a little over 2 miles.
+        let miles = distance_miles(37.7601, -122.4661, 37.7946, -122.3999);
+        assert!((3.5..4.5).contains(&miles), "{miles} miles");
+
+        assert_eq!(distance_miles(37.0, -122.0, 37.0, -122.0), 0.0);
+
+        // SF to NYC, a well-known 2570 miles.
+        let coast_to_coast = distance_miles(37.7749, -122.4194, 40.7128, -74.006);
+        assert!(
+            (2550.0..2600.0).contains(&coast_to_coast),
+            "{coast_to_coast}"
+        );
+    }
+
+    #[test]
+    fn errors_read_as_sentences() {
+        assert_eq!(
+            Error::Incomplete("hourly data").to_string(),
+            "Open-Meteo returned no hourly data."
+        );
+        assert_eq!(
+            Error::NoSuchPlace("qqqq".to_owned()).to_string(),
+            "No place matched \u{201c}qqqq\u{201d}."
+        );
+    }
+}

--- a/src/units.rs
+++ b/src/units.rs
@@ -1,0 +1,183 @@
+//! Typed physical quantities.
+//!
+//! Everything on this page is a bare number until it isn't: the comfort model
+//! is calibrated in Celsius and metres per second, the page displays Fahrenheit
+//! and miles per hour, and half the arithmetic is on *differences* between
+//! temperatures rather than temperatures. That last one is the trap — a
+//! temperature converts with an offset and a temperature difference does not,
+//! so one `f64` for both lets a 5°C swing render as 41°F.
+//!
+//! Each quantity here stores a single canonical unit behind a private field,
+//! so a unit exists only at the two boundaries: a named constructor going in
+//! and a named accessor coming out. Nothing in between carries a unit, which
+//! means there is no `Fahrenheit(celsius_value)` mistake available to make, and
+//! comparing or averaging never has to ask which scale it is holding.
+//!
+//! Quantities that never convert and never mix — irradiance in W/m²,
+//! percentages, millimetres of rain, the one grid distance in miles — stay as
+//! `f64`. A newtype there would be ceremony.
+
+use std::ops::Sub;
+
+/// An air or felt temperature. Stored in Celsius.
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub struct Temperature(f64);
+
+/// A difference between two temperatures. Stored in Celsius degrees.
+///
+/// Separate from [`Temperature`] because it converts without the 32° offset.
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub struct TemperatureDelta(f64);
+
+/// A wind speed. Stored in metres per second.
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
+pub struct Speed(f64);
+
+impl Temperature {
+    pub const fn from_celsius(degrees: f64) -> Self {
+        Temperature(degrees)
+    }
+
+    pub fn celsius(self) -> f64 {
+        self.0
+    }
+
+    pub fn fahrenheit(self) -> f64 {
+        self.0 * 9.0 / 5.0 + 32.0
+    }
+
+    /// Whole degrees Fahrenheit, which is all this page ever displays.
+    pub fn round_fahrenheit(self) -> i32 {
+        self.fahrenheit().round() as i32
+    }
+
+    pub fn min(self, other: Self) -> Self {
+        Temperature(self.0.min(other.0))
+    }
+
+    pub fn max(self, other: Self) -> Self {
+        Temperature(self.0.max(other.0))
+    }
+}
+
+impl Sub for Temperature {
+    type Output = TemperatureDelta;
+
+    fn sub(self, other: Self) -> TemperatureDelta {
+        TemperatureDelta(self.0 - other.0)
+    }
+}
+
+impl TemperatureDelta {
+    /// No offset: a five degree change is a nine degree change.
+    pub fn fahrenheit(self) -> f64 {
+        self.0 * 9.0 / 5.0
+    }
+
+    pub fn round_fahrenheit(self) -> i32 {
+        self.fahrenheit().round() as i32
+    }
+}
+
+impl Speed {
+    pub const fn from_meters_per_second(speed: f64) -> Self {
+        Speed(speed)
+    }
+
+    /// The unit Steadman's formula is calibrated in.
+    pub fn meters_per_second(self) -> f64 {
+        self.0
+    }
+
+    pub fn miles_per_hour(self) -> f64 {
+        self.0 * 2.236_936
+    }
+
+    pub fn round_miles_per_hour(self) -> i32 {
+        self.miles_per_hour().round() as i32
+    }
+
+    pub fn max(self, other: Self) -> Self {
+        Speed(self.0.max(other.0))
+    }
+}
+
+/// A speed difference is still a speed; there is no offset to get wrong, so
+/// this needs no separate delta type the way temperature does.
+impl Sub for Speed {
+    type Output = Speed;
+
+    fn sub(self, other: Self) -> Speed {
+        Speed(self.0 - other.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn temperatures_convert_with_the_offset() {
+        assert_eq!(Temperature::from_celsius(0.0).fahrenheit(), 32.0);
+        assert_eq!(Temperature::from_celsius(100.0).fahrenheit(), 212.0);
+        assert_eq!(Temperature::from_celsius(-40.0).fahrenheit(), -40.0);
+        assert_eq!(Temperature::from_celsius(21.0).celsius(), 21.0);
+    }
+
+    #[test]
+    fn differences_convert_without_the_offset() {
+        // The whole reason this is a separate type.
+        assert_eq!(TemperatureDelta(5.0).fahrenheit(), 9.0);
+        assert_eq!(TemperatureDelta(0.0).fahrenheit(), 0.0);
+        assert_eq!(TemperatureDelta(-10.0).fahrenheit(), -18.0);
+    }
+
+    #[test]
+    fn subtracting_temperatures_produces_a_difference() {
+        let warmer = Temperature::from_celsius(20.0);
+        let colder = Temperature::from_celsius(15.0);
+
+        // Converting the difference and differencing the conversions agree,
+        // which is exactly what a single f64 would let you get wrong.
+        assert_eq!((warmer - colder).fahrenheit(), 9.0);
+        assert!(((warmer.fahrenheit() - colder.fahrenheit()) - 9.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn speed_converts_and_subtracts() {
+        let wind = Speed::from_meters_per_second(10.0);
+        assert!((wind.miles_per_hour() - 22.369).abs() < 0.01);
+        assert_eq!(wind.meters_per_second(), 10.0);
+
+        let difference = Speed::from_meters_per_second(9.0) - Speed::from_meters_per_second(4.0);
+        assert_eq!(difference.meters_per_second(), 5.0);
+    }
+
+    #[test]
+    fn extremes_pick_the_right_end() {
+        let cool = Temperature::from_celsius(3.0);
+        let warm = Temperature::from_celsius(8.0);
+        assert_eq!(cool.min(warm), cool);
+        assert_eq!(cool.max(warm), warm);
+
+        let breeze = Speed::from_meters_per_second(4.0);
+        let gale = Speed::from_meters_per_second(11.0);
+        assert_eq!(breeze.max(gale), gale);
+    }
+
+    #[test]
+    fn rounding_is_to_whole_display_units() {
+        assert_eq!(Temperature::from_celsius(17.6).round_fahrenheit(), 64);
+        assert_eq!(TemperatureDelta(-2.4).round_fahrenheit(), -4);
+        assert_eq!(
+            Speed::from_meters_per_second(6.5).round_miles_per_hour(),
+            15
+        );
+    }
+
+    #[test]
+    fn ordering_does_not_depend_on_the_display_unit() {
+        assert!(Temperature::from_celsius(10.0) < Temperature::from_celsius(20.0));
+        assert!(Speed::from_meters_per_second(3.0) < Speed::from_meters_per_second(30.0));
+    }
+}

--- a/static/js/weather.js
+++ b/static/js/weather.js
@@ -1,0 +1,111 @@
+/**
+ * Remembers which location the weather page should open on.
+ *
+ * The page itself is fully server-rendered; this only handles the one piece of
+ * state that belongs to the browser rather than the repo. There is no database
+ * behind this site, so the committed home location in `src/locations.rs` is the
+ * default and `localStorage` holds any personal override.
+ *
+ * Loaded synchronously in `<head>` on purpose: a bare `/weather` visit with a
+ * saved override redirects before the body paints, so there is no flash of the
+ * wrong city.
+ */
+
+const STORAGE_KEY = "weather:default";
+
+/**
+ * localStorage throws in Safari private browsing rather than returning null,
+ * and a weather page is not worth an exception.
+ * @returns {string | null}
+ */
+function savedDefault() {
+  try {
+    return window.localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @param {string | null} value
+ */
+function saveDefault(value) {
+  try {
+    if (value === null) {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } else {
+      window.localStorage.setItem(STORAGE_KEY, value);
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Only query strings this page itself generates are ever followed, so a value
+ * planted in storage cannot redirect anywhere but back into /weather.
+ * @param {string} param
+ */
+function isSafeParam(param) {
+  return /^(loc=[a-z0-9-]+|lat=-?\d+(\.\d+)?&lon=-?\d+(\.\d+)?&name=[^&#/\\]*)$/.test(
+    param,
+  );
+}
+
+// Redirect before anything renders. `replace` keeps the bare URL out of the
+// back-button history, so Back still leaves the site.
+if (window.location.pathname === "/weather" && window.location.search === "") {
+  const saved = savedDefault();
+  if (saved && isSafeParam(saved)) {
+    window.location.replace(`/weather?${saved}`);
+  }
+}
+
+document.addEventListener("DOMContentLoaded", () => {
+  const button = document.getElementById("weather-set-default");
+  const note = document.getElementById("weather-default-note");
+  if (
+    !(button instanceof HTMLButtonElement) ||
+    !(note instanceof HTMLElement)
+  ) {
+    return;
+  }
+
+  const param = button.dataset.param ?? "";
+  if (!isSafeParam(param)) {
+    return;
+  }
+
+  /**
+   * @param {string} message
+   */
+  function showNote(message) {
+    note.textContent = message;
+    note.hidden = message === "";
+  }
+
+  function render() {
+    const saved = savedDefault();
+    if (saved === param) {
+      button.textContent = "Clear default";
+      showNote("This page opens here.");
+    } else {
+      button.textContent = "Open here by default";
+      showNote(saved ? "Another location is your default." : "");
+    }
+  }
+
+  // Hidden until now so the control never appears without its behaviour.
+  button.hidden = false;
+  render();
+
+  button.addEventListener("click", () => {
+    const clearing = savedDefault() === param;
+    if (saveDefault(clearing ? null : param)) {
+      render();
+    } else {
+      showNote("This browser is not saving settings.");
+    }
+  });
+});

--- a/static/styles.css
+++ b/static/styles.css
@@ -100,6 +100,10 @@ body {
   position: sticky;
   top: 0;
 
+  /* Without this the header is a positioned element at `z-index: auto`, so any
+     other positioned element later in the document paints over it. */
+  z-index: 20;
+
   font-size: 0.875rem;
   line-height: 1.25rem;
 
@@ -172,4 +176,790 @@ body {
 
 .hidden {
   display: none;
+}
+
+/* ==================== Weather ==================== */
+
+.weather {
+  /* Sun and shade get one colour each and keep it everywhere: headline,
+     chart, table and legend. Nothing else on the page competes with them. */
+  --weather-sun: #b45309;
+  --weather-sun-soft: #fbbf24;
+  --weather-shade: #1d4ed8;
+  --weather-shade-soft: #93c5fd;
+  --weather-ink: #171717;
+
+  /*
+   * The 0-10 comfort scale, as a diverging ramp: blue at the cold pole, a
+   * neutral midpoint at 5 ("perfect"), red at the hot pole. Generated in OKLCH
+   * with equal steps per arm, so lightness is monotone outward from the middle
+   * and the two arms are mirror images.
+   *
+   * Used as chip backgrounds rather than text colour, which keeps every step
+   * legible: --weather-ink on the darkest step still measures 4.95:1, and the
+   * number is always printed inside the chip, so colour never carries the
+   * reading on its own.
+   */
+  --weather-feel-0: #408ee7;
+  --weather-feel-1: #65a2ec;
+  --weather-feel-2: #87b6f0;
+  --weather-feel-3: #a8caf4;
+  --weather-feel-4: #c9ddf6;
+  --weather-feel-5: #f0efec;
+  --weather-feel-6: #f6d2ca;
+  --weather-feel-7: #f3b6a9;
+  --weather-feel-8: #ed9a89;
+  --weather-feel-9: #e67d69;
+  --weather-feel-10: #de5e47;
+  --weather-muted: #6b7280;
+  --weather-rule: #e5e7eb;
+  --weather-surface: #f9fafb;
+
+  color: var(--weather-ink);
+  padding-bottom: 3rem;
+  max-width: 42rem;
+}
+
+.weather-place {
+  padding-top: 1.5rem;
+}
+
+.weather-place-name {
+  margin: 0;
+  font-size: 1.5rem;
+  line-height: 2rem;
+}
+
+.weather-place-detail {
+  margin: 0.125rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--weather-muted);
+}
+
+.weather-error {
+  margin: 1rem 0;
+  padding: 0.75rem 1rem;
+  border-left: 3px solid var(--weather-sun);
+  background-color: var(--weather-surface);
+  font-size: 0.875rem;
+}
+
+.weather-eyebrow {
+  margin: 0;
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--weather-muted);
+}
+
+/* ---- Headline: the range and the swing, never the air temperature ---- */
+
+.weather-headline {
+  margin-top: 1.75rem;
+}
+
+.weather-hero {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+  margin: 0.25rem 0 0;
+}
+
+.weather-hero-value {
+  font-size: 3.25rem;
+  line-height: 1.1;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  font-variant-numeric: tabular-nums;
+}
+
+.weather-hero-gloss {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.weather-hero-label {
+  font-size: 1rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.weather-hero-share {
+  font-size: 0.8125rem;
+  color: var(--weather-muted);
+}
+
+.weather-bounds {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem 1.5rem;
+  margin: 0.875rem 0 0;
+}
+
+.weather-bound {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.weather-bound-label {
+  font-size: 0.6875rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--weather-muted);
+}
+
+.weather-bound-value {
+  font-size: 1.125rem;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.weather-range-note {
+  margin: 0.25rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--weather-muted);
+}
+
+.weather-verdict {
+  margin-top: 1rem;
+  padding: 0.875rem 1rem;
+  background-color: var(--weather-surface);
+  border-radius: 0.5rem;
+}
+
+.weather-verdict-line {
+  margin: 0;
+  font-size: 1rem;
+  line-height: 1.5;
+}
+
+.weather-verdict-line:first-child {
+  font-weight: 600;
+}
+
+.weather-verdict-line + .weather-verdict-line {
+  margin-top: 0.375rem;
+  color: #374151;
+}
+
+/* ---- Right now ---- */
+
+.weather-now {
+  margin-top: 1.75rem;
+}
+
+.weather-pair {
+  display: flex;
+  gap: 1.5rem;
+  align-items: baseline;
+  margin: 0.375rem 0 0;
+}
+
+.weather-pair-sun,
+.weather-pair-shade {
+  display: flex;
+  flex-direction: column;
+}
+
+.weather-pair-label {
+  font-size: 0.6875rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--weather-muted);
+}
+
+.weather-pair-value {
+  font-size: 2rem;
+  line-height: 1.15;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.weather-pair-none {
+  font-size: 0.8125rem;
+  color: var(--weather-muted);
+}
+
+.weather-now-meta {
+  margin: 0.375rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--weather-muted);
+}
+
+/* ---- Day chart ---- */
+
+.weather-chart-section {
+  margin-top: 1.75rem;
+}
+
+.weather-chart {
+  display: block;
+  width: 100%;
+  height: auto;
+  overflow: visible;
+}
+
+.weather-chart-grid {
+  stroke: var(--weather-rule);
+  stroke-width: 1;
+}
+
+.weather-chart-tick {
+  fill: var(--weather-muted);
+  font-size: 8px;
+  font-variant-numeric: tabular-nums;
+}
+
+.weather-chart-sun {
+  fill: none;
+  stroke: var(--weather-sun);
+  stroke-width: 2;
+  stroke-linejoin: round;
+}
+
+.weather-chart-shade {
+  fill: none;
+  stroke: var(--weather-shade);
+  stroke-width: 2;
+  stroke-linejoin: round;
+}
+
+.weather-chart-yesterday {
+  fill: none;
+  stroke: #9ca3af;
+  stroke-width: 1;
+  stroke-dasharray: 3 2;
+}
+
+.weather-chart-sunset {
+  stroke: var(--weather-ink);
+  stroke-width: 1;
+  stroke-dasharray: 2 2;
+}
+
+.weather-chart-now {
+  stroke: var(--weather-ink);
+  stroke-width: 1.5;
+}
+
+.weather-chart-marker {
+  fill: var(--weather-ink);
+  font-size: 8px;
+  font-weight: 600;
+}
+
+.weather-legend {
+  margin: 0.25rem 0 0;
+  font-size: 0.75rem;
+  color: var(--weather-muted);
+}
+
+.weather-legend-sun,
+.weather-legend-shade,
+.weather-legend-yesterday {
+  font-weight: 600;
+}
+
+.weather-legend-sun {
+  color: var(--weather-sun);
+}
+
+.weather-legend-shade {
+  color: var(--weather-shade);
+}
+
+.weather-legend-yesterday {
+  color: var(--weather-ink);
+}
+
+/* ---- Tables ---- */
+
+.weather-section-title {
+  margin: 0 0 0.5rem;
+  font-size: 0.875rem;
+  letter-spacing: 0.02em;
+}
+
+.weather-hours-section,
+.weather-compare {
+  margin-top: 2rem;
+}
+
+.weather-table-scroll {
+  overflow-x: auto;
+}
+
+.weather-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.weather-table th,
+.weather-table td {
+  padding: 0.3125rem 0.25rem;
+  text-align: right;
+  white-space: nowrap;
+}
+
+.weather-table thead th {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  color: var(--weather-muted);
+  border-bottom: 1px solid var(--weather-rule);
+}
+
+.weather-table tbody th {
+  text-align: left;
+  font-weight: 400;
+}
+
+.weather-table td:first-of-type,
+.weather-table th:first-child {
+  padding-left: 0;
+}
+
+.weather-table td:last-child {
+  padding-right: 0;
+}
+
+.weather-unit {
+  display: block;
+  font-weight: 400;
+  opacity: 0.75;
+}
+
+.weather-cell-score {
+  display: inline-block;
+  min-width: 2.125rem;
+  border-radius: 0.375rem;
+  padding: 0.0625rem 0.25rem;
+  font-weight: 600;
+  color: var(--weather-ink);
+}
+
+.weather-cell-degrees {
+  display: block;
+  font-size: 0.6875rem;
+  color: var(--weather-muted);
+}
+
+.weather-cell-sun,
+.weather-cell-shade {
+  line-height: 1.25;
+}
+
+.weather-cell-empty {
+  color: var(--weather-rule);
+}
+
+.weather-row-past {
+  opacity: 0.45;
+}
+
+.weather-row-now th,
+.weather-row-now td {
+  background-color: #fef3c7;
+}
+
+.weather-row-now th::after {
+  content: " \00b7 now";
+  color: var(--weather-muted);
+  font-size: 0.6875rem;
+}
+
+.weather-row-sunset td {
+  text-align: left;
+  padding: 0.375rem 0;
+  font-size: 0.6875rem;
+  color: var(--weather-muted);
+  border-top: 1px dashed var(--weather-rule);
+  border-bottom: 1px dashed var(--weather-rule);
+  white-space: normal;
+}
+
+.weather-delta {
+  font-weight: 600;
+}
+
+.weather-delta-up {
+  color: var(--weather-sun);
+}
+
+.weather-delta-down {
+  color: var(--weather-shade);
+}
+
+.weather-delta-flat {
+  color: var(--weather-muted);
+  font-weight: 400;
+}
+
+.weather-secondary {
+  margin: 0.5rem 0 0;
+  font-size: 0.75rem;
+  color: var(--weather-muted);
+}
+
+.weather-resolution {
+  margin: 2rem 0 0;
+  padding-top: 0.75rem;
+  border-top: 1px solid var(--weather-rule);
+  font-size: 0.75rem;
+  line-height: 1.5;
+  color: var(--weather-muted);
+}
+
+/* ---- Location switcher ---- */
+
+.weather-locations {
+  margin-top: 2rem;
+}
+
+.weather-pins {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.weather-pin-item {
+  display: flex;
+}
+
+.weather-pin {
+  display: block;
+  padding: 0.4375rem 0.75rem;
+  border: 1px solid var(--weather-rule);
+  border-radius: 999px;
+  font-size: 0.8125rem;
+  text-decoration: none;
+  color: var(--weather-ink);
+}
+
+.weather-pin:hover {
+  border-color: var(--weather-muted);
+}
+
+.weather-pin-active {
+  background-color: var(--weather-ink);
+  border-color: var(--weather-ink);
+  color: #fff;
+}
+
+.weather-search {
+  margin-top: 0.875rem;
+}
+
+.weather-search-label {
+  display: block;
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--weather-muted);
+  margin-bottom: 0.25rem;
+}
+
+.weather-search-row {
+  display: flex;
+  gap: 0.375rem;
+}
+
+.weather-search-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0.5rem 0.625rem;
+  border: 1px solid var(--weather-rule);
+  border-radius: 0.375rem;
+  font: inherit;
+  font-size: 1rem; /* 16px keeps iOS from zooming the page on focus */
+}
+
+.weather-search-button,
+.weather-default-button {
+  padding: 0.5rem 0.875rem;
+  border: 1px solid var(--weather-rule);
+  border-radius: 0.375rem;
+  background-color: #fff;
+  font: inherit;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+
+.weather-search-button:hover,
+.weather-default-button:hover {
+  border-color: var(--weather-muted);
+}
+
+.weather-alternates {
+  margin: 0.5rem 0 0;
+  font-size: 0.8125rem;
+  color: var(--weather-muted);
+}
+
+.weather-default {
+  margin: 0.75rem 0 0;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.weather-default-note {
+  font-size: 0.75rem;
+  color: var(--weather-muted);
+}
+
+/* ---- Comfort scale chips ---- */
+
+.weather-feel-0 {
+  background-color: var(--weather-feel-0);
+}
+
+.weather-feel-1 {
+  background-color: var(--weather-feel-1);
+}
+
+.weather-feel-2 {
+  background-color: var(--weather-feel-2);
+}
+
+.weather-feel-3 {
+  background-color: var(--weather-feel-3);
+}
+
+.weather-feel-4 {
+  background-color: var(--weather-feel-4);
+}
+
+.weather-feel-5 {
+  background-color: var(--weather-feel-5);
+}
+
+.weather-feel-6 {
+  background-color: var(--weather-feel-6);
+}
+
+.weather-feel-7 {
+  background-color: var(--weather-feel-7);
+}
+
+.weather-feel-8 {
+  background-color: var(--weather-feel-8);
+}
+
+.weather-feel-9 {
+  background-color: var(--weather-feel-9);
+}
+
+.weather-feel-10 {
+  background-color: var(--weather-feel-10);
+}
+
+/* The pale middle steps would otherwise have no edge against the page. */
+.weather-feel-0,
+.weather-feel-1,
+.weather-feel-2,
+.weather-feel-3,
+.weather-feel-4,
+.weather-feel-5,
+.weather-feel-6,
+.weather-feel-7,
+.weather-feel-8,
+.weather-feel-9,
+.weather-feel-10 {
+  box-shadow: inset 0 0 0 1px rgb(0 0 0 / 8%);
+}
+
+/* SVG stripes take the same colours as flat fills, without the chip edge. */
+.weather-chart-band-fill {
+  box-shadow: none;
+}
+
+.weather-chart-band-fill.weather-feel-0 {
+  fill: var(--weather-feel-0);
+}
+
+.weather-chart-band-fill.weather-feel-1 {
+  fill: var(--weather-feel-1);
+}
+
+.weather-chart-band-fill.weather-feel-2 {
+  fill: var(--weather-feel-2);
+}
+
+.weather-chart-band-fill.weather-feel-3 {
+  fill: var(--weather-feel-3);
+}
+
+.weather-chart-band-fill.weather-feel-4 {
+  fill: var(--weather-feel-4);
+}
+
+.weather-chart-band-fill.weather-feel-5 {
+  fill: var(--weather-feel-5);
+}
+
+.weather-chart-band-fill.weather-feel-6 {
+  fill: var(--weather-feel-6);
+}
+
+.weather-chart-band-fill.weather-feel-7 {
+  fill: var(--weather-feel-7);
+}
+
+.weather-chart-band-fill.weather-feel-8 {
+  fill: var(--weather-feel-8);
+}
+
+.weather-chart-band-fill.weather-feel-9 {
+  fill: var(--weather-feel-9);
+}
+
+.weather-chart-band-fill.weather-feel-10 {
+  fill: var(--weather-feel-10);
+}
+
+/* ---- Probe: a score with its raw data on hover or tap ---- */
+
+/*
+ * The tooltip is positioned against the whole row of numbers, not against the
+ * individual number, so it can never be pushed off the side of a phone screen
+ * by a trigger that happens to sit near the edge. Only one is open at a time,
+ * so a shared anchor costs nothing.
+ */
+.weather-hero,
+.weather-bounds,
+.weather-pair {
+  position: relative;
+}
+
+.weather-probe {
+  display: inline-block;
+}
+
+.weather-probe-trigger {
+  /* Longhand, not the `font` shorthand: the shorthand would reset the size set
+     by the wrapper's modifier class. */
+  font-family: inherit;
+  font-size: inherit;
+  font-weight: inherit;
+  line-height: inherit;
+  color: var(--weather-ink);
+  border: 0;
+  border-radius: 0.5rem;
+  padding: 0.0625em 0.3em;
+  cursor: help;
+  font-variant-numeric: tabular-nums;
+}
+
+.weather-probe-tip {
+  position: absolute;
+  top: calc(100% + 0.375rem);
+  left: 0;
+  /* Above the sticky header: a tooltip is transient and explicitly asked for,
+     so it should never be the thing that gets clipped. */
+  z-index: 30;
+  display: block;
+  width: max-content;
+  max-width: 100%;
+  padding: 0.5rem 0.625rem;
+  border-radius: 0.375rem;
+  background-color: #1f2937;
+  color: #f9fafb;
+  font-size: 0.75rem;
+  line-height: 1.45;
+  font-weight: 400;
+  text-align: left;
+  letter-spacing: 0;
+  text-transform: none;
+  visibility: hidden;
+  opacity: 0;
+}
+
+/*
+ * Hover covers the desktop case; focus covers touch, where tapping a button
+ * focuses it. No script is involved, which matters under a
+ * `default-src 'self'` Content-Security-Policy.
+ */
+.weather-probe:hover .weather-probe-tip,
+.weather-probe-trigger:focus + .weather-probe-tip {
+  visibility: visible;
+  opacity: 1;
+}
+
+.weather-probe-tip-head {
+  display: block;
+  font-weight: 600;
+}
+
+.weather-probe-tip-body {
+  display: block;
+  color: #d1d5db;
+}
+
+/* ---- Scale key ---- */
+
+.weather-key-list {
+  list-style: none;
+  margin: 0.5rem 0 0;
+  padding: 0;
+  font-size: 0.8125rem;
+}
+
+.weather-key-item {
+  display: flex;
+  align-items: baseline;
+  gap: 0.5rem;
+  padding: 0.125rem 0;
+}
+
+.weather-key-chip {
+  flex: 0 0 auto;
+  width: 2rem;
+  text-align: center;
+  border-radius: 0.5rem;
+  padding: 0.0625rem 0;
+  font-variant-numeric: tabular-nums;
+  font-weight: 600;
+}
+
+/* ---- Method ---- */
+
+.weather-method {
+  margin-top: 2rem;
+  border-top: 1px solid var(--weather-rule);
+  padding-top: 0.75rem;
+}
+
+.weather-method-summary {
+  font-size: 0.8125rem;
+  color: var(--weather-muted);
+  cursor: pointer;
+}
+
+.weather-method-body {
+  font-size: 0.8125rem;
+  line-height: 1.6;
+  color: #374151;
+}
+
+.weather-method-body p {
+  margin: 0.75rem 0 0;
+}
+
+@media (min-width: 40rem) {
+  .weather-range {
+    font-size: 4rem;
+  }
+
+  .weather-table th,
+  .weather-table td {
+    padding: 0.375rem 0.5rem;
+  }
 }

--- a/templates/index.html.jinja
+++ b/templates/index.html.jinja
@@ -3,6 +3,9 @@
 {% block content %}
   <ul>
     <li>
+      <a class="link" href="/weather">Weather</a>
+    </li>
+    <li>
       <a class="link" href="/microwave">Microwave Time Calculator</a>
     </li>
     <li>

--- a/templates/layout.html.jinja
+++ b/templates/layout.html.jinja
@@ -18,6 +18,13 @@
         <ul class="header-nav-ul">
           <li class="header-nav-li">
             <a
+              class="header-nav-link {% if path == "/weather" %}header-nav-link-active{% endif %}"
+              href="/weather"
+              >Weather</a
+            >
+          </li>
+          <li class="header-nav-li">
+            <a
               class="header-nav-link {% if path == "/uuid" %}header-nav-link-active{% endif %}"
               href="/uuid"
               >UUID</a

--- a/templates/weather.html.jinja
+++ b/templates/weather.html.jinja
@@ -1,0 +1,477 @@
+{% extends "layout.html.jinja" %}
+
+{#
+  A score, with the numbers behind it on hover or tap. The trigger is a real
+  button so a tap focuses it on touch devices and the tooltip opens from CSS
+  alone -- the page's Content-Security-Policy forbids inline script, and this
+  needs no script at all.
+#}
+{% macro probe(reading, modifier) %}
+  <span class="weather-probe {{ modifier }}">
+    <button
+      class="weather-probe-trigger weather-feel-{{ reading.level }}"
+      type="button"
+    >
+      {{- reading.score -}}
+    </button>
+    <span class="weather-probe-tip" role="tooltip">
+      <span class="weather-probe-tip-head"
+        >{{ reading.score }} &middot; {{ reading.label }}</span
+      >
+      <span class="weather-probe-tip-body">
+        {{ reading.hour_label }} &middot; felt {{ reading.degrees }}&deg;<br />
+        air {{ reading.air_f }}&deg; &middot; wind {{ reading.wind_mph }} mph
+        &middot; {{ reading.humidity }}% humidity &middot; {{ reading.cloud }}%
+        cloud
+      </span>
+    </span>
+  </span>
+{% endmacro %}
+
+{% block title %}Weather - {{ super() }}{% endblock %}
+
+{% block head %}
+  <script src="/js/weather.js"></script>
+{% endblock %}
+
+{% block content %}
+  <div class="weather">
+    <header class="weather-place">
+      <h2 class="weather-place-name">{{ place_name }}</h2>
+      {% if place_detail != "" %}
+        <p class="weather-place-detail">{{ place_detail }}</p>
+      {% endif %}
+    </header>
+
+    {% if let Some(message) = error %}
+      <p class="weather-error">{{ message }}</p>
+    {% endif %}
+
+    {% if let Some(today) = report %}
+      <section class="weather-headline">
+        <p class="weather-eyebrow">How {{ today.headline_scope }} feels</p>
+        <p class="weather-hero">
+          {% call probe(today.typical, "weather-hero-value") %}{% endcall %}
+          <span class="weather-hero-gloss">
+            <span class="weather-hero-label">{{ today.typical.label }}</span>
+            <span class="weather-hero-share"
+              >for {{ today.typical_share }}% of it</span
+            >
+          </span>
+        </p>
+        <p class="weather-bounds">
+          <span class="weather-bound">
+            <span class="weather-bound-label">coolest, out of the sun</span>
+            {% call probe(today.low, "weather-bound-value") %}{% endcall %}
+          </span>
+          <span class="weather-bound">
+            <span class="weather-bound-label"
+              >warmest, {{ today.high_hour }}</span
+            >
+            {% call probe(today.high, "weather-bound-value") %}{% endcall %}
+          </span>
+        </p>
+        <p class="weather-range-note">
+          {{ today.low.degrees }}&deg; to {{ today.high.degrees }}&deg;, a
+          {{ today.swing_f }}&deg; swing.
+        </p>
+        <div class="weather-verdict">
+          {% for line in today.verdict %}
+            <p class="weather-verdict-line">{{ line }}</p>
+          {% endfor %}
+        </div>
+      </section>
+
+      {% if let Some(now) = today.now %}
+        <section class="weather-now">
+          <p class="weather-eyebrow">Right now &middot; {{ now.label }}</p>
+          <p class="weather-pair">
+            {% if now.has_sun %}
+              <span class="weather-pair-sun">
+                <span class="weather-pair-label">in sun</span>
+                {% call probe(now.sun, "weather-pair-value") %}{% endcall %}
+              </span>
+              <span class="weather-pair-shade">
+                <span class="weather-pair-label">in shade</span>
+                {% call probe(now.shade, "weather-pair-value") %}{% endcall %}
+              </span>
+            {% else %}
+              <span class="weather-pair-shade">
+                <span class="weather-pair-label">feels like</span>
+                {% call probe(now.shade, "weather-pair-value") %}{% endcall %}
+              </span>
+              <span class="weather-pair-none">no direct sun on you</span>
+            {% endif %}
+          </p>
+          <p class="weather-now-meta">
+            Air {{ now.air_f }}&deg; &middot; wind {{ now.wind_mph }}
+            mph{% if let Some(versus) = now.versus_yesterday %}
+              &middot; {{ versus }}
+            {% endif %}
+          </p>
+        </section>
+      {% endif %}
+
+      {% if let Some(chart) = today.chart %}
+        <section class="weather-chart-section">
+          <svg
+            class="weather-chart"
+            viewBox="0 0 {{ chart.width }} {{ chart.height }}"
+            role="img"
+            aria-label="How the day feels hour by hour, on a 0 to 10 scale. Today runs from {{ today.low.score }} out of the sun to {{ today.high.score }} at its warmest."
+          >
+            {% for band in chart.bands %}
+              <rect
+                class="weather-chart-band-fill weather-feel-{{ band.level }}"
+                x="{{ chart.plot_left }}"
+                y="{{ band.y }}"
+                width="{{ chart.plot_width }}"
+                height="{{ band.height }}"
+              />
+            {% endfor %}
+
+            {% for line in chart.grid %}
+              <line
+                class="weather-chart-grid"
+                x1="{{ chart.plot_left }}"
+                y1="{{ line.y }}"
+                x2="{{ chart.plot_right }}"
+                y2="{{ line.y }}"
+              />
+              <text
+                class="weather-chart-tick"
+                x="{{ chart.grid_label_x }}"
+                y="{{ line.y }}"
+                text-anchor="end"
+                dominant-baseline="middle"
+              >
+                {{- line.label -}}
+              </text>
+            {% endfor %}
+
+            {% if let Some(yesterday) = chart.yesterday_band %}
+              <polygon
+                class="weather-chart-yesterday"
+                points="{{ yesterday }}"
+              />
+            {% endif %}
+
+            <polyline class="weather-chart-sun" points="{{ chart.sun_line }}" />
+            <polyline
+              class="weather-chart-shade"
+              points="{{ chart.shade_line }}"
+            />
+
+            {% if let Some(sunset) = chart.sunset %}
+              <line
+                class="weather-chart-sunset"
+                x1="{{ sunset.x }}"
+                y1="{{ chart.plot_top }}"
+                x2="{{ sunset.x }}"
+                y2="{{ chart.plot_bottom }}"
+              />
+              <text
+                class="weather-chart-marker"
+                x="{{ sunset.label_x }}"
+                y="{{ chart.marker_label_y }}"
+                text-anchor="middle"
+              >
+                {{- sunset.label -}}
+              </text>
+            {% endif %}
+
+            {% if let Some(now) = chart.now %}
+              <line
+                class="weather-chart-now"
+                x1="{{ now.x }}"
+                y1="{{ chart.plot_top }}"
+                x2="{{ now.x }}"
+                y2="{{ chart.plot_bottom }}"
+              />
+              {% if now.show_label %}
+                <text
+                  class="weather-chart-marker"
+                  x="{{ now.label_x }}"
+                  y="{{ chart.marker_label_y }}"
+                  text-anchor="middle"
+                >
+                  {{- now.label -}}
+                </text>
+              {% endif %}
+            {% endif %}
+
+            {% for tick in chart.ticks %}
+              <text
+                class="weather-chart-tick"
+                x="{{ tick.x }}"
+                y="{{ chart.axis_label_y }}"
+                text-anchor="middle"
+              >
+                {{- tick.label -}}
+              </text>
+            {% endfor %}
+          </svg>
+          <p class="weather-legend">
+            <span class="weather-legend-sun">Orange</span> is full sun,
+            <span class="weather-legend-shade">blue</span> is shade; the gap
+            between them is the part you get to choose.
+            {% if chart.yesterday_band.is_some() %}
+              <span class="weather-legend-yesterday">Dashed</span> is yesterday.
+            {% endif %}
+            Background stripes are the scale below.
+          </p>
+        </section>
+      {% endif %}
+
+      <section class="weather-hours-section">
+        <h3 class="weather-section-title">Hour by hour</h3>
+        <div class="weather-table-scroll">
+          <table class="weather-table weather-hours">
+            <thead>
+              <tr>
+                <th scope="col">Hour</th>
+                <th scope="col">In sun</th>
+                <th scope="col">In shade</th>
+                <th scope="col">Air</th>
+                <th scope="col">Wind<span class="weather-unit">mph</span></th>
+                <th scope="col">Cloud</th>
+                <th scope="col">Rain</th>
+              </tr>
+            </thead>
+            <tbody>
+              {% for hour in today.hours %}
+                <tr
+                  class="{% if hour.is_now %}weather-row-now{% endif %} {% if hour.past %}weather-row-past{% endif %}"
+                >
+                  <th scope="row">{{ hour.label }}</th>
+                  <td class="weather-cell-sun">
+                    {% if hour.has_sun %}
+                      <span
+                        class="weather-cell-score weather-feel-{{ hour.sun_level }}"
+                        >{{ hour.sun_score }}</span
+                      >
+                      <span class="weather-cell-degrees"
+                        >{{ hour.sun_f }}&deg;</span
+                      >
+                    {% else %}
+                      <span
+                        class="weather-cell-empty"
+                        aria-label="no direct sun"
+                        >&mdash;</span
+                      >
+                    {% endif %}
+                  </td>
+                  <td class="weather-cell-shade">
+                    <span
+                      class="weather-cell-score weather-feel-{{ hour.shade_level }}"
+                      >{{ hour.shade_score }}</span
+                    >
+                    <span class="weather-cell-degrees"
+                      >{{ hour.shade_f }}&deg;</span
+                    >
+                  </td>
+                  <td>{{ hour.air_f }}&deg;</td>
+                  <td>{{ hour.wind_mph }}</td>
+                  <td>{{ hour.cloud }}%</td>
+                  <td>{{ hour.rain_chance }}%</td>
+                </tr>
+                {% if hour.sunset_follows %}
+                  <tr class="weather-row-sunset">
+                    <td colspan="7">
+                      Sunset {{ today.sunset_label }} &mdash; direct sun ends,
+                      only the shade column applies after this
+                    </td>
+                  </tr>
+                {% endif %}
+              {% endfor %}
+            </tbody>
+          </table>
+        </div>
+        <p class="weather-secondary">
+          Air high {{ today.air_high_f }}&deg; &middot; low
+          {{ today.air_low_f }}&deg; &middot; sunrise {{ today.sunrise_label }}
+          &middot; sunset {{ today.sunset_label }} &middot; rain
+          {{ today.rain_chance }}% at its likeliest, {{ today.rain_total_in }}
+          in expected
+        </p>
+      </section>
+
+      {% if today.has_yesterday %}
+        <section class="weather-compare">
+          <h3 class="weather-section-title">Against yesterday</h3>
+          <div class="weather-table-scroll">
+            <table class="weather-table">
+              <thead>
+                <tr>
+                  <th scope="col">&nbsp;</th>
+                  <th scope="col">Today</th>
+                  <th scope="col">Yesterday</th>
+                  <th scope="col">Change</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% for row in today.comparisons %}
+                  <tr>
+                    <th scope="row">{{ row.label }}</th>
+                    <td>{{ row.today }}</td>
+                    <td>{{ row.yesterday }}</td>
+                    <td class="weather-delta weather-delta-{{ row.direction }}">
+                      {{- row.delta -}}
+                    </td>
+                  </tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+          <p class="weather-secondary">
+            Yesterday is the same daylight window, so the two columns cover the
+            same hours of the day.
+          </p>
+        </section>
+      {% endif %}
+
+      <p class="weather-resolution">
+        The model grid point used here is {{ today.grid_distance_mi }} mi from
+        the pin, at {{ today.grid_elevation_ft }} ft. Places closer together
+        than about a mile land in the same cell, so this cannot tell one block
+        from the next &mdash; it can tell the Inner Sunset from the Financial
+        District, and that gap is real. Times are {{ today.timezone }}, last
+        read at {{ today.updated_label }}.
+      </p>
+    {% endif %}
+
+    <section class="weather-locations">
+      <h3 class="weather-section-title">Location</h3>
+      <ul class="weather-pins">
+        {% for pin in pins %}
+          <li class="weather-pin-item">
+            <a
+              class="weather-pin {% if pin.active %}weather-pin-active{% endif %}"
+              href="{{ pin.href }}"
+              title="{{ pin.detail }}"
+              >{{ pin.name }}</a
+            >
+          </li>
+        {% endfor %}
+      </ul>
+
+      <form class="weather-search" method="get" action="/weather">
+        <label class="weather-search-label" for="q">Somewhere else</label>
+        <div class="weather-search-row">
+          <input
+            class="weather-search-input"
+            type="search"
+            id="q"
+            name="q"
+            value="{{ search_query }}"
+            placeholder="City or neighborhood"
+            autocomplete="off"
+          />
+          <button class="weather-search-button" type="submit">Look up</button>
+        </div>
+      </form>
+
+      {% if !alternates.is_empty() %}
+        <p class="weather-alternates">
+          Or did you mean:
+          {% for alternate in alternates %}
+            <a class="link" href="{{ alternate.href }}">{{ alternate.label }}</a
+            >{% if !loop.last %},{% endif %}
+          {% endfor %}
+        </p>
+      {% endif %}
+
+      <p class="weather-default">
+        <button
+          class="weather-default-button"
+          type="button"
+          id="weather-set-default"
+          data-param="{{ place_param }}"
+          hidden
+        >
+          Open here by default
+        </button>
+        <span
+          class="weather-default-note"
+          id="weather-default-note"
+          hidden
+        ></span>
+      </p>
+    </section>
+
+    <details class="weather-method">
+      <summary class="weather-method-summary">What the 0 to 10 means</summary>
+      <div class="weather-method-body">
+        <p>
+          A personal scale, not a published index. 5 is the weather this site's
+          owner likes best; everything else is described relative to it. The
+          steps are closest together through the mild middle, where a couple of
+          degrees genuinely changes what goes on, and widest at the ends, where
+          everything is just very cold or very hot.
+        </p>
+        <ul class="weather-key-list">
+          {% for step in key %}
+            <li class="weather-key-item">
+              <span class="weather-key-chip weather-feel-{{ step.level }}"
+                >{{ step.level }}</span
+              >
+              <span
+                >{{ step.label }} &middot; about {{ step.degrees }}&deg;</span
+              >
+            </li>
+          {% endfor %}
+        </ul>
+      </div>
+    </details>
+
+    <details class="weather-method">
+      <summary class="weather-method-summary">
+        How these numbers are made
+      </summary>
+      <div class="weather-method-body">
+        <p>
+          <strong>Felt temperature</strong> is Steadman's apparent temperature
+          in its radiation form, the one the Australian Bureau of Meteorology
+          publishes:
+          <code class="code"
+            >AT = Ta + 0.348e &minus; 0.70v + 0.70Q/(v + 10) &minus; 4.25</code
+          >, where <em>e</em> is vapour pressure, <em>v</em> the 10 m wind and
+          <em>Q</em> the net radiation a body absorbs. It was chosen over the
+          usual "feels like" because those are a heat index above about 80&deg;
+          spliced to a wind chill below about 50&deg;, and plain air temperature
+          in between &mdash; which is precisely the range this page is for.
+          Steadman's stays continuous across the whole band and takes wind,
+          humidity and sunlight as real inputs.
+        </p>
+        <p>
+          <strong>Q</strong> is built as the standard radiation budget for a
+          standing person: the beam scaled by Fanger's projected-area factor,
+          plus diffuse sky and ground-reflected shortwave over the body's sky
+          and ground view factors, plus a longwave term using Brunt's sky
+          emissivity blended toward a black body by cloud cover. The sun and
+          shade figures differ only in Q &mdash; shade drops the direct beam and
+          reflects off shaded ground. Q is expressed relative to a radiatively
+          neutral environment, so an overcast night lands on Steadman's
+          non-radiation formula rather than drifting away from it.
+        </p>
+        <p>
+          <strong>Data</strong> is Open-Meteo, picked because it is the only
+          free source that publishes direct normal, direct horizontal and
+          diffuse radiation hourly &mdash; without those three the sun/shade
+          split cannot be computed at all. No API key, so this server holds no
+          secret. Yesterday's column comes from the same endpoint's past days,
+          which is model analysis for hours that have already happened, not a
+          reading from a thermometer down the street.
+        </p>
+        <p>
+          <strong
+            >The sun figure assumes nothing is between you and the sun.</strong
+          >
+          Under an awning, on the north side of a building, or in a street
+          canyon, read the shade column. Real days are spent moving between the
+          two, which is why both are shown.
+        </p>
+      </div>
+    </details>
+  </div>
+{% endblock %}


### PR DESCRIPTION
## The problem

Air temperature is a poor predictor of how a day will feel. Two days with the same high can feel twenty degrees apart depending on sun, wind and cloud cover, and every weather app leads with the least informative number.

`/weather` answers one question: **what do I need to wear, and do I need to carry a layer for later.** Anything that doesn't change that answer isn't on the page.

## What it shows

A single **0-10 comfort score** as the headline, with felt temperature as supporting detail. The scale is personally calibrated — 5 is the weather this site's owner likes best, 0 and 10 are "do not go outside" at either end — and every score is colour-coded so the day's shape reads at a glance. Hovering or tapping any score reveals the air temperature, wind, humidity and cloud behind it.

Below that: the coolest it gets out of the sun, the warmest it gets and when, an hour-by-hour table with the sun/shade pair for every hour, a sunset marker, and an explicit comparison against yesterday's actuals.

## The model

**Felt temperature** is Steadman's apparent temperature in its radiation form, the version the Australian Bureau of Meteorology publishes:

```
AT = Ta + 0.348e - 0.70v + 0.70Q/(v + 10) - 4.25
```

Chosen because the usual "feels like" is a heat index above ~80°F spliced to a wind chill below ~50°F, with raw air temperature in between — precisely the band this page exists for. Steadman's stays continuous across it and takes wind, humidity and sunlight as first-class inputs. Its explicit radiation term is what lets one model produce both halves of the sun/shade pair; `Q` is built from the standard radiation budget for a standing person (Fanger's projected-area factor, sky/ground view factors, Brunt sky emissivity blended by cloud).

**Sun and shade are the bounds, not the expectation.** Cloud cover is not the same thing as shade, so the headline blends the two by how much sky is actually clear. Under a solid overcast it collapses onto the shade figure rather than reporting a sunlit ceiling nobody stands in.

## Data

Open-Meteo, the only free source publishing direct normal, direct horizontal and diffuse radiation hourly — without those three the sun/shade split cannot be computed at all. The alternatives are compared in the module docs. No API key, so this server holds no secret, and yesterday's analysis comes from the same endpoint.

## Constraints

No new infrastructure and no new dependencies. Forecasts are cached in memory for ten minutes, saved locations are committed to `src/locations.rs`, and the browser keeps any personal default in `localStorage`. `reqwest`'s `query` and `json` features stay off, so URLs are built with a small helper and decoded with `serde_json` — both already present. The page's CSP is `default-src 'self'`, so there is no inline script or style; the tooltips are CSS-only.

## Also in here

- **`src/units.rs`** — each quantity stores one canonical unit behind a private field. A temperature converts with an offset and a temperature difference does not, so a single `f64` for both lets a 5°C swing render as 41°F.
- **A sticky-header fix** — `.header` had no `z-index`, so any positioned element later in the document painted over it. Pre-existing; this page surfaced it.

## Testing

173 Rust unit tests and 14 Playwright specs. The comfort model, the scale, the time helpers, the chart geometry and the query resolution are all covered directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
